### PR TITLE
Android bluetooth dial

### DIFF
--- a/infra/bt/client.go
+++ b/infra/bt/client.go
@@ -1,0 +1,5 @@
+package bt
+
+var Instance Client = Bluetooth{}
+
+type Client interface{}

--- a/mobile/android/node/bluetooth.go
+++ b/mobile/android/node/bluetooth.go
@@ -1,0 +1,110 @@
+package astral
+
+import (
+	"context"
+	"github.com/cryptopunkscc/astrald/infra"
+	"github.com/cryptopunkscc/astrald/infra/bt"
+	"io"
+	"log"
+)
+
+// ==================================== Mobile bluetooth adapter ====================================
+
+// Bluetooth gomobile binding interface for bluetooth have to be implemented and injected from android sources.
+type Bluetooth interface {
+	Dial(address []byte) (BluetoothSocket, error)
+}
+
+type BluetoothSocket interface {
+	io.WriteCloser      // Basic IO operations
+	Read(Writer) error  // Gobind-hack, the replacement for standard io.Reader
+	Outbound() bool     // Returns true if we are the active party, false otherwise
+	LocalAddr() string  // Returns local network address if known, nil otherwise
+	RemoteAddr() string // Returns the other party's network address if known, nil otherwise
+}
+
+// ==================================== Mobile bluetooth wrapper ====================================
+
+func newBluetoothAdapter(client Bluetooth) bt.Client {
+	return &bluetooth{
+		base:   bt.Bluetooth{},
+		native: client,
+	}
+}
+
+// bluetooth adapts native android bluetooth to astral infra interfaces.
+type bluetooth struct {
+	base   bt.Bluetooth
+	native Bluetooth
+}
+
+var _ infra.Network = &bluetooth{}
+var _ infra.Unpacker = &bluetooth{}
+var _ infra.Dialer = &bluetooth{}
+
+func (b *bluetooth) Name() string {
+	return b.base.Name()
+}
+
+func (b *bluetooth) Unpack(network string, data []byte) (infra.Addr, error) {
+	return b.base.Unpack(network, data)
+}
+
+func (b *bluetooth) Dial(_ context.Context, addr infra.Addr) (infra.Conn, error) {
+	socket, err := b.native.Dial(addr.Pack())
+	if err != nil {
+		return nil, err
+	}
+	return newBluetoothSocket(socket), nil
+}
+
+func newBluetoothSocket(socket BluetoothSocket) *bluetoothSocket {
+	reader, writer := io.Pipe()
+	go func() {
+		err := socket.Read(writer)
+		if err != nil {
+			log.Println("BT socket read error", err)
+		}
+	}()
+	return &bluetoothSocket{
+		BluetoothSocket: socket,
+		localAddr:       nil,
+		remoteAddr:      infraAddr(socket.RemoteAddr()),
+		reader:          reader,
+		writer:          writer,
+	}
+}
+
+func infraAddr(addr string) infra.Addr {
+	parsed, err := bt.Parse(addr)
+	if err != nil {
+		log.Println("Cannot parse bt address", addr, err)
+	}
+	return parsed
+}
+
+type bluetoothSocket struct {
+	BluetoothSocket
+	localAddr  infra.Addr
+	remoteAddr infra.Addr
+	reader     *io.PipeReader
+	writer     *io.PipeWriter
+}
+
+var _ infra.Conn = &bluetoothSocket{}
+
+func (c *bluetoothSocket) LocalAddr() infra.Addr {
+	return c.localAddr
+}
+
+func (c *bluetoothSocket) RemoteAddr() infra.Addr {
+	return c.remoteAddr
+}
+
+func (c bluetoothSocket) Read(bytes []byte) (l int, err error) {
+	return c.reader.Read(bytes)
+}
+
+func (c bluetoothSocket) Write(bytes []byte) (l int, err error) {
+	return c.BluetoothSocket.Write(bytes)
+}

--- a/mobile/android/node/main.go
+++ b/mobile/android/node/main.go
@@ -2,6 +2,7 @@ package astral
 
 import (
 	"context"
+	"github.com/cryptopunkscc/astrald/infra/bt"
 	"github.com/cryptopunkscc/astrald/lib/astral"
 	"github.com/cryptopunkscc/astrald/mod/admin"
 	"github.com/cryptopunkscc/astrald/mod/apphost"
@@ -23,12 +24,17 @@ var dataDir string
 func Start(
 	dir string,
 	mods Modules,
+	bluetooth Bluetooth,
 ) error {
 	dataDir = dir
 	nodeDir := filepath.Join(dataDir, "node")
 	err := os.MkdirAll(nodeDir, 0700)
 	if err != nil {
 		return err
+	}
+
+	if bluetooth != nil {
+		bt.Instance = newBluetoothAdapter(bluetooth)
 	}
 
 	log.Println("Staring astrald")

--- a/mobile/android/node/src/main/AndroidManifest.xml
+++ b/mobile/android/node/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="cc.cryptopunks.astral.wrapper">
 
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/mobile/android/node/src/main/java/cc/cryptopunks/astral/wrapper/Astral.kt
+++ b/mobile/android/node/src/main/java/cc/cryptopunks/astral/wrapper/Astral.kt
@@ -46,8 +46,9 @@ fun Context.startAstral() {
             try {
                 val dir = File(applicationInfo.dataDir).absolutePath
                 val modules = Modules.from(resolveMethods())
+                val bluetooth = Bluetooth()
 
-                Astral.start(dir, modules)
+                Astral.start(dir, modules, bluetooth)
             } catch (e: Throwable) {
                 e.printStackTrace()
             } finally {

--- a/mobile/android/node/src/main/java/cc/cryptopunks/astral/wrapper/Bluetooth.kt
+++ b/mobile/android/node/src/main/java/cc/cryptopunks/astral/wrapper/Bluetooth.kt
@@ -1,0 +1,103 @@
+package cc.cryptopunks.astral.wrapper
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothSocket
+import astral.Writer
+import java.io.InputStream
+
+internal class Bluetooth : astral.Bluetooth {
+
+    private val name = "AstralNode"
+
+    private val adapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+
+    override fun dial(address: ByteArray): Socket {
+        address.reverse()
+        println("Dial to ${address.toHex()}")
+
+        val remoteDevice = adapter.getRemoteDevice(address)
+
+        val socket = remoteDevice.createInsecureRfcommSocket(1)
+
+        adapter.cancelDiscovery()
+
+        return try {
+            socket.connect()
+            println("Connected to ${address.toHex()}")
+
+            Socket(
+                outbound = true,
+                btSocket = socket,
+                localAddress = null,
+            )
+        } catch (e: Throwable) {
+            socket.close()
+            e.printStackTrace()
+            throw e
+        }
+    }
+
+    class Socket(
+        private val localAddress: String?,
+        private val outbound: Boolean,
+        private val btSocket: BluetoothSocket,
+    ) : astral.BluetoothSocket {
+
+
+        override fun localAddr(): String? {
+            println("Getting local address: $localAddress")
+            return localAddress
+        }
+
+        override fun outbound(): Boolean {
+            println("Getting outbound: $outbound")
+            return outbound
+        }
+
+        override fun remoteAddr(): String? {
+            return btSocket.remoteDevice.address.also {
+                println("Getting remote address $it")
+            }
+        }
+
+        override fun close() {
+            println("Closing connection")
+            btSocket.outputStream.flush()
+            btSocket.close()
+            println("Connection closed")
+        }
+
+        override fun read(writer: Writer) {
+            btSocket.inputStream.copyTo(writer)
+        }
+
+        override fun write(bytes: ByteArray): Long {
+            btSocket.outputStream.write(bytes)
+            return bytes.size.toLong()
+        }
+    }
+}
+
+private fun InputStream.copyTo(writer: Writer) {
+    val size = 16 * 1024
+    val buffer = ByteArray(size)
+    var len: Int
+    while (true) {
+        len = read(buffer)
+        when (len) {
+            size -> writer.write(buffer)
+            -1 -> break
+            else -> writer.write(buffer.copyOf(len))
+        }
+    }
+}
+
+private fun BluetoothDevice.createInsecureRfcommSocket(port: Int): BluetoothSocket {
+    val m = javaClass.getMethod("createInsecureRfcommSocket", Int::class.javaPrimitiveType)
+    val soc = m.invoke(this, port)
+    return soc as BluetoothSocket
+}
+
+private fun ByteArray.toHex(): String =
+    joinToString(separator = ":") { eachByte -> "%02x".format(eachByte) }

--- a/node/infra/infra.go
+++ b/node/infra/infra.go
@@ -31,7 +31,7 @@ type Infra struct {
 	inet      *inet.Inet
 	tor       *tor.Tor
 	gateway   *gw.Gateway
-	bluetooth *bt.Bluetooth
+	bluetooth bt.Client
 	logLevel  int
 }
 

--- a/node/infra/networks.go
+++ b/node/infra/networks.go
@@ -37,7 +37,7 @@ func (i *Infra) setupNetworks(ctx context.Context, cfg config.Infra) error {
 
 	// bluetooth
 	if err := i.setupNetwork(func() (infra.Network, error) {
-		return bt.New()
+		return bt.Instance, nil
 	}); err != nil {
 		i.Logf(log.Normal, "bt error: %s", err)
 	}


### PR DESCRIPTION
Limiited support for bluetooth on android. only dial method available.

How to test manually:
1. Install node on android device executing `./clean.sh && ./installApk.sh`.
1. Make sure android node has received bluetooth address from remote node.
1. Turn on bluetooth and turn off wifi and mobile connection.
1. Try connect to remote node using anc.