### PR TITLE
Wrapper API

### DIFF
--- a/lib/wrapper/api.go
+++ b/lib/wrapper/api.go
@@ -1,0 +1,45 @@
+package wrapper
+
+import (
+	"github.com/cryptopunkscc/astrald/auth/id"
+	"io"
+)
+
+// Api interface for astral apps that have to be either standalone and embedded in node.
+type Api interface {
+
+	// Register new astral port under a given name.
+	Register(name string) (Port, error)
+
+	// Query a specific port by name. For calling a local service, pass empty string as nodeId.
+	Query(nodeID id.Identity, query string) (io.ReadWriteCloser, error)
+
+	// Resolve node identity by name.
+	Resolve(name string) (id.Identity, error)
+}
+
+// Port for receiving local and remote requests.
+type Port interface {
+
+	// Next returns channel for receiving incoming requests
+	Next() <-chan Request
+
+	// Close and unregister the port.
+	Close() error
+}
+
+// Request for new astral connection.
+type Request interface {
+
+	// Caller returns identity of callers node.
+	Caller() id.Identity
+
+	// Query returns the requested port name.
+	Query() string
+
+	// Accept incoming connection and start the stream.
+	Accept() (io.ReadWriteCloser, error)
+
+	// Reject the incoming request.
+	Reject() error
+}

--- a/lib/wrapper/apphost/adapter.go
+++ b/lib/wrapper/apphost/adapter.go
@@ -1,0 +1,64 @@
+package apphost
+
+import (
+	"github.com/cryptopunkscc/astrald/auth/id"
+	"github.com/cryptopunkscc/astrald/lib/astral"
+	"github.com/cryptopunkscc/astrald/lib/wrapper"
+	"io"
+)
+
+var _ wrapper.Api = Adapter{}
+
+type Adapter struct{}
+
+func (a Adapter) Resolve(name string) (id.Identity, error) {
+	return astral.Resolve(name)
+}
+
+func (a Adapter) Register(name string) (wrapper.Port, error) {
+	listener, err := astral.Listen(name)
+	if err != nil {
+		return nil, err
+	}
+	return appHostPort{listener}, err
+}
+
+func (a Adapter) Query(nodeID id.Identity, query string) (rw io.ReadWriteCloser, err error) {
+	return astral.Dial(nodeID, query)
+}
+
+type appHostPort struct{ *astral.Listener }
+
+func (a appHostPort) Next() <-chan wrapper.Request {
+	c := make(chan wrapper.Request)
+	go func() {
+		defer close(c)
+		for query := range a.QueryCh() {
+			q := query
+			c <- &appHostRequest{q}
+		}
+	}()
+	return c
+}
+
+func (a appHostPort) Close() error {
+	return a.Close()
+}
+
+type appHostRequest struct{ query *astral.Query }
+
+func (a appHostRequest) Caller() id.Identity {
+	return a.query.RemoteIdentity()
+}
+
+func (a appHostRequest) Accept() (io.ReadWriteCloser, error) {
+	return a.query.Accept()
+}
+
+func (a appHostRequest) Reject() error {
+	return a.query.Reject()
+}
+
+func (a appHostRequest) Query() string {
+	return a.query.Query()
+}

--- a/lib/wrapper/embedded/adapter.go
+++ b/lib/wrapper/embedded/adapter.go
@@ -1,0 +1,86 @@
+package embedded
+
+import (
+	"context"
+	"github.com/cryptopunkscc/astrald/auth/id"
+	"github.com/cryptopunkscc/astrald/hub"
+	"github.com/cryptopunkscc/astrald/lib/wrapper"
+	"github.com/cryptopunkscc/astrald/node"
+	"io"
+)
+
+var _ wrapper.Api = &Adapter{}
+
+type Adapter struct {
+	Ctx  context.Context
+	Node *node.Node
+}
+
+func (a *Adapter) Resolve(name string) (identity id.Identity, err error) {
+	if name == "localnode" {
+		return a.Node.Identity(), nil
+	}
+
+	if identity, err = id.ParsePublicKeyHex(name); err == nil {
+		return
+	}
+
+	identity, err = a.Node.Contacts.ResolveIdentity(name)
+	return
+}
+
+type astralPort struct {
+	port hub.Port
+}
+
+type astralRequest struct {
+	query *hub.Query
+}
+
+func (a *Adapter) Register(name string) (p wrapper.Port, err error) {
+	hp, err := a.Node.Ports.RegisterContext(a.Ctx, name)
+	if err != nil {
+		return
+	}
+	p = &astralPort{*hp}
+	return
+}
+
+func (a *Adapter) Query(nodeID id.Identity, query string) (rwc io.ReadWriteCloser, err error) {
+	return a.Node.Query(a.Ctx, nodeID, query)
+}
+
+func (p *astralPort) Next() <-chan wrapper.Request {
+	c := make(chan wrapper.Request)
+	go func() {
+		defer close(c)
+		for query := range p.port.Queries() {
+			q := query
+			c <- &astralRequest{q}
+		}
+	}()
+	return c
+}
+
+func (p *astralPort) Close() error {
+	return p.port.Close()
+}
+
+func (r *astralRequest) Caller() (identity id.Identity) {
+	if !r.query.IsLocal() {
+		identity = r.query.Link().RemoteIdentity()
+	}
+	return
+}
+
+func (r *astralRequest) Query() string {
+	return r.query.Query()
+}
+
+func (r *astralRequest) Accept() (io.ReadWriteCloser, error) {
+	return r.query.Accept()
+}
+
+func (r *astralRequest) Reject() error {
+	return r.query.Reject()
+}


### PR DESCRIPTION
Unix sockets are not available on android. 
To reduce TCP bottleneck, standalone golang app can be compiled into node to access it directly without touching apphost.

This pull request adds API interface and adapters to apphost and node.
It is required for golang applications that have to be standalone or embedded depending on platform requirements.