### PR TITLE
Drive protocols draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 cmd/astrald/astrald
+.obsidian

--- a/proto/app-drive.md
+++ b/proto/app-drive.md
@@ -1,0 +1,67 @@
+# drive (draft) 
+application protocol for file management
+
+## Overview
+
+|name|desc|
+|-|-|
+|pull|pull resources from given uri into storage|
+|fetch|similar to pull but saves only metadata and links to encountered blobs|
+|read|open read stream for uri|
+|share|make specified resources available to read for a given peer|
+|revoke|oposite to share|
+|mount|makes view to specified resources in native file system|
+
+## Commands
+
+### pull
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[c]c|uri|universal resource identifier to file|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|[c][40]c|ids|files identities|
+
+### fetch
+arguments
+
+|type|name|desc|
+|-|-|-|
+||||
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+||||
+
+### read
+arguments
+
+|type|name|desc|
+|-|-|-|
+||||
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+||||
+
+### read
+arguments
+
+|type|name|desc|
+|-|-|-|
+||||
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+||||

--- a/proto/block/protocol.md
+++ b/proto/block/protocol.md
@@ -115,3 +115,11 @@ Error codes
 ### end (0xff)
 
 End takes no arguments and rerturns a single null byte which is the final byte of the protocol.
+
+## Side effects
+
+### [finalize](./protocol.md#finalize%20%280x04%29) -> [event:publish](../mod-event-pub.md#publish)
+
+|channel|data|type|
+|-|-|-|
+|"block"|id|[40]byte|

--- a/proto/mod-contacts.md
+++ b/proto/mod-contacts.md
@@ -1,0 +1,37 @@
+# contacts protocol (draft)
+
+contacts is a asynchronous protocol for retriving contacts details
+
+## Overview
+
+|name|desc|visibility|
+|-|-|-|
+|list|obtain contacts list|private|
+
+## Data
+
+### contact
+
+|type|name|desc|
+|-|-|-|
+|[c]c|name|key used to obtain the metadata parameter value|
+|[33]c|id|regex pattern for matching meta-data value|
+
+
+## Commands
+
+### list
+returned values
+
+|type|name|desc|
+|-|-|-|
+|[]contact|contacts|list of known contacts|
+
+## Side effects
+
+### new contact -> [event:publish](mod-event-pub.md#publish)
+any newly recognised contact is published to event channel 
+
+|channel|data|type|
+|-|-|-|
+|contact|contact|[uint16]byte|

--- a/proto/mod-event-pub.md
+++ b/proto/mod-event-pub.md
@@ -15,7 +15,7 @@ arguments
 |type|name|desc|
 |-|-|-|
 |[c]c|channel|name of channel where evens are published|
-|[c]c|data|data frame passed to channel|
+|[s]c|data|data frame passed to channel|
 
 returned values
 

--- a/proto/mod-event-pub.md
+++ b/proto/mod-event-pub.md
@@ -1,0 +1,24 @@
+# publish event protocol (draft)
+asynchronius, asymetric, protocol for publishing events
+
+## Overview
+
+|name|desc|visibility|
+|-|-|-|
+|publish|send event to all subscribers in channel|private|
+
+## Commands
+
+### publish
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[c]c|channel|name of channel where evens are published|
+|[c]c|data|data frame passed to channel|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|c|error|zero or an error code|

--- a/proto/mod-event-sub.md
+++ b/proto/mod-event-sub.md
@@ -1,0 +1,34 @@
+# subscribe event protocol (draft)
+asynchronius, asymetric, protocol for subscribing events
+
+## Overview
+
+|name|desc|visibility|
+|-|-|-|
+|subscribe|subscribe to event channel|private|
+
+## Commands
+
+### subscribe
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[c]c|channel|name of channel where events are published|
+|[filter](./util-filter#filter)|filter|meta-data values filter|
+|c|pulse|pulse signal for keeping connection alive|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|c|code|zero or an error code|
+|[c]c|data|data frame passed to channel|
+
+flow:
+1. send `channel` name
+2. receive `code`
+	1. on error return
+3. spawn async workers
+	1. inside loop, send `pulse` signal and wait a delay
+	2. inside loop, read `data` frames

--- a/proto/srv-file-metadata.md
+++ b/proto/srv-file-metadata.md
@@ -1,0 +1,42 @@
+# content metadata protocol (draft)
+protocol for accesing files metadata
+
+## Overview
+
+|name|desc|visibility|
+|-|-|-|
+|query|obtain filtered metadata cursor|private|
+
+## Commands
+
+### query
+returned values
+
+|type|name|desc|
+|-|-|-|
+|byte|error|zero or an error code|
+
+On success, a [util-cursor](util-cursor.md) protocol session begins, providing metadata items.
+
+### close
+returned values
+
+|type|name|desc|
+|-|-|-|
+|0|ok|finalization byte|
+
+## Side effects
+
+### new metadata -> [event:publish](mod-event-pub.md#publish)
+any newly recognised metadata is published to event channel 
+
+|channel|data|type|
+|-|-|-|
+|meta|metadata|[uint16]byte|
+
+### new blob -> [event:publish](mod-event-pub.md#publish)
+any newly recognised blob id is published to event channel 
+
+|channel|data|type|
+|-|-|-|
+|blob|id|[40]byte|

--- a/proto/srv-file-private.md
+++ b/proto/srv-file-private.md
@@ -1,0 +1,44 @@
+# private content protocol (draft)
+protocol for local content management
+
+## Note
+consider to merging into [io:store](./store/protocol.md)
+
+## Overview
+
+|name|desc|visibility|
+|-|-|-|
+|list|get list of files identities|private|
+|close|close the connection|public|
+
+## Commands
+
+### list
+arguments
+
+|type|name|desc|
+|-|-|-|
+|uint32|from|timestamp of the oldest element to include in results|
+
+returned value
+
+|type|name|desc|
+|-|-|-|
+|uint64|amount|amount of file identities|
+|[amount]fileId|id|list of files identittes|
+
+### close
+returned values
+
+|type|name|desc|
+|-|-|-|
+|0|ok|finalization byte|
+
+## Dependencies
+
+### [event:subscribe](mod-event-sub.md#subscribe)
+required to collect identities into list
+
+|channel|filter|data|type|
+|-|-|-|-|
+|block|0|id|[40]byte|

--- a/proto/srv-file-shared.md
+++ b/proto/srv-file-shared.md
@@ -1,0 +1,75 @@
+# shared content protocol (draft)
+protocol for remote content access
+
+## Overview
+
+|name|desc|visibility|
+|-|-|-|
+|grant|grant the peer read access to the files|private|
+|revoke|revoke the peer read access to the files|private|
+|fetch|fetch identities of accessible files|public|
+|sync|download the selected files from peer|public|
+|close|close the connection|public|
+
+## Commands
+
+### grant
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[]byte|peer|identity of peer to grant access|
+|[][]byte|ids|list of files identities, that peer has access to|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|byte|error|zero or an error code|
+
+### revoke
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[]byte|peer|identity of peer to revoke access|
+|[][]byte|ids|list of files identities to revoke|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|byte|error|zero or an error code|
+
+### fetch
+arguments
+
+|type|name|desc|
+|-|-|-|
+|uint64|timestamp|timestamp of previous fetch|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|[uint16][40]byte|ids|files identities|
+
+### sync
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[40]byte|id|file id|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|byte|error|zero or an error code|
+
+### close
+returned values
+
+|type|name|desc|
+|-|-|-|
+|0|ok|finalization byte|

--- a/proto/srv-file-shared.md
+++ b/proto/srv-file-shared.md
@@ -8,6 +8,7 @@ protocol for remote content access
 |grant|grant the peer read access to the files|private|
 |revoke|revoke the peer read access to the files|private|
 |fetch|fetch identities of accessible files|public|
+|subscribe|subscribe identities of accessible files|public|
 |sync|download the selected files from peer|public|
 |close|close the connection|public|
 
@@ -53,6 +54,24 @@ returned values
 |type|name|desc|
 |-|-|-|
 |[uint16][40]byte|ids|files identities|
+
+### subscribe
+
+inherits [util:sub#subscribe](util-sub#subscribe)
+
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[0]c|filter|filtering not supported|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|[40]byte|data|file identity|
+
+
 
 ### sync
 arguments

--- a/proto/util-cursor.md
+++ b/proto/util-cursor.md
@@ -1,0 +1,66 @@
+# cursor protocol (draft)
+protocol for iterating over large data set
+
+## Overview
+
+|name|desc|visibility|
+|-|-|-|
+|filter|setup byte stream filter|private|
+|next|get specified amount of items and move offset|private|
+|seek|skip specified amount of items and move offset|private|
+|close|close the cursor|private|
+
+## Commands
+
+### filter
+arguments
+
+|type|name|desc|
+|-|-|-|
+|[filter](./util-filter#filter)|filter|meta-data values filter|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|c|error|zero or an error code|
+
+### next
+arguments
+
+|type|name|desc|
+|-|-|-|
+|int32|amount|amont of items to get|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|int32|amount|amount of items to return, can be lower then requested amount|
+|[][]byte|items|array of encoded items|
+
+#### Note
+Amount can be negative for navigating backward.
+
+### seek
+arguments
+
+|type|name|desc|
+|-|-|-|
+|int32|amount|amont of items to skip|
+
+returned values
+
+|type|name|desc|
+|-|-|-|
+|int32|amount|amount of items to return|
+
+#### Note
+Amount can be negative for navigating backward.
+
+### close
+returned values
+
+|type|name|desc|
+|-|-|-|
+|0|ok|finalization byte|

--- a/proto/util-filter.md
+++ b/proto/util-filter.md
@@ -1,0 +1,18 @@
+# filtering protocol (draft)
+protocol for filtering data streams
+
+## Data types
+
+### matcher
+
+|type|name|desc|
+|-|-|-|
+|[c]c|key|key used to obtain the metadata parameter value|
+|[c]c|pattern|regex pattern for matching meta-data value|
+
+### filter
+
+|type|name|desc|
+|-|-|-|
+|\[c\][matcher](util-filter.md#matcher)|matchers|list of stream regex matchers|
+

--- a/proto/util-sub.md
+++ b/proto/util-sub.md
@@ -1,4 +1,4 @@
-# subscribe event protocol (draft)
+# subscribe protocol (draft)
 asynchronius, asymetric, protocol for subscribing events
 
 ## Overview
@@ -14,8 +14,8 @@ arguments
 
 |type|name|desc|
 |-|-|-|
-|[c]c|channel|name of channel where events are published|
-|[filter](./util-filter#filter)|filter|meta-data values filter|
+|[c]c|name|name of subscriber|
+|\*|filter|meta-data values filter|
 |c|pulse|pulse signal for keeping connection alive|
 
 returned values
@@ -23,7 +23,7 @@ returned values
 |type|name|desc|
 |-|-|-|
 |c|code|zero or an error code|
-|[s]c|data|data frame passed to channel|
+|\*|data|data frame passed to channel|
 
 flow:
 1. send `channel` name


### PR DESCRIPTION
[app-drive](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/app-drive.md)
[mod-contacts](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/mod-contacts.md)
[mod-event-pub](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/mod-event-pub.md)
[mod-event-sub](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/mod-event-sub.md)
[srv-file-metadata](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/srv-file-metadata.md)
[srv-file-private](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/srv-file-private.md)
[srv-file-shared](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/srv-file-shared.md)
[util-cursor](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/util-cursor.md)
[util-filter](https://github.com/cryptopunkscc/astrald/blob/proto/drive/proto/util-filter.md)