### PR TITLE
Dynamic sqlite driver

### DIFF
--- a/cmd/astrald/main.go
+++ b/cmd/astrald/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"github.com/cryptopunkscc/astrald/debug"
 	"github.com/cryptopunkscc/astrald/node"
+	"github.com/cryptopunkscc/astrald/node/assets"
+	"github.com/glebarez/sqlite"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -78,6 +80,7 @@ func main() {
 	}()
 
 	// start the node
+	assets.SqliteOpen = sqlite.Open
 	node, err := node.NewCoreNode(astralRoot)
 	if err != nil {
 		fmt.Println("init error:", err)

--- a/node/assets/file_store.go
+++ b/node/assets/file_store.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cryptopunkscc/astrald/log"
-	"github.com/glebarez/sqlite"
 	"gopkg.in/yaml.v2"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -85,6 +84,8 @@ func (store *FileStore) StoreYAML(name string, in interface{}) error {
 	return store.Write(name, bytes)
 }
 
+var SqliteOpen func(string) gorm.Dialector
+
 func (store *FileStore) OpenDB(name string) (*gorm.DB, error) {
 	if name == "" {
 		return nil, errors.New("invalid name")
@@ -93,7 +94,7 @@ func (store *FileStore) OpenDB(name string) (*gorm.DB, error) {
 		name = name + ".db"
 	}
 	return gorm.Open(
-		sqlite.Open(filepath.Join(store.baseDir, name)),
+		SqliteOpen(filepath.Join(store.baseDir, name)),
 		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)},
 	)
 }


### PR DESCRIPTION
The library `github.com/glebarez/sqlite` is failing on Android OS with error:
`libc                    Fatal signal 31 (SIGSYS), code 1 (SYS_SECCOMP) in tid 3817 (pool-1-thread-1), pid 3322 (ks.astral.agent)`


This pull request provides a simple workaround that allows to pass the SQLite driver dynamically.