### PR TITLE
gomobile: bypass net.Interfaces and net.InterfaceAddrs

### DIFF
--- a/mod/ether/src/module.go
+++ b/mod/ether/src/module.go
@@ -116,7 +116,7 @@ func (mod *Module) readBroadcast() (*ether.SignedBroadcast, *net.UDPAddr, error)
 }
 
 func (mod *Module) broadcast(data []byte) error {
-	ifaces, err := net.Interfaces()
+	ifaces, err := NetInterfaces()
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (mod *Module) setupSocket(ctx context.Context) (err error) {
 	return
 }
 
-func isInterfaceEnabled(iface net.Interface) bool {
+func isInterfaceEnabled(iface NetInterface) bool {
 	return (iface.Flags&net.FlagUp != 0) &&
 		(iface.Flags&net.FlagBroadcast != 0) &&
 		(iface.Flags&net.FlagLoopback == 0)

--- a/mod/ether/src/net.go
+++ b/mod/ether/src/net.go
@@ -1,0 +1,21 @@
+package ether
+
+import "net"
+
+type NetInterface struct {
+	Flags net.Flags
+	Addrs func() ([]net.Addr, error)
+}
+
+var NetInterfaces = DefaultNetInterfaces
+
+func DefaultNetInterfaces() (out []NetInterface, err error) {
+	arr, err := net.Interfaces()
+	for _, i := range arr {
+		out = append(out, NetInterface{
+			Flags: i.Flags,
+			Addrs: i.Addrs,
+		})
+	}
+	return
+}

--- a/mod/objects/src/create.go
+++ b/mod/objects/src/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/objects"
 )
 
-const MaxAlloc = 1 * 1024 * 1024 * 1024 * 1024 //1TB
+const MaxAlloc int64 = 1 * 1024 * 1024 * 1024 * 1024 //1TB; gomobile requires explicit int64 type.
 
 type Creator struct {
 	objects.Repository
@@ -23,7 +23,7 @@ func (mod *Module) Create(o *objects.CreateOpts) (objects.Writer, error) {
 		return nil, errors.New("alloc cannot be less than 0")
 	}
 
-	if opts.Alloc > MaxAlloc {
+	if int64(opts.Alloc) > MaxAlloc {
 		return nil, errors.New("alloc exceeds limit")
 	}
 

--- a/mod/tcp/src/module.go
+++ b/mod/tcp/src/module.go
@@ -53,7 +53,7 @@ func (mod *Module) ListenPort() int {
 func (mod *Module) localIPs() ([]tcp.IP, error) {
 	list := make([]tcp.IP, 0)
 
-	ifaceAddrs, err := net.InterfaceAddrs()
+	ifaceAddrs, err := InterfaceAddrs()
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (mod *Module) localEndpoints() (list []exonet.Endpoint) {
 }
 
 func (mod *Module) watchAddresses(ctx context.Context) {
-	_, err := net.InterfaceAddrs()
+	_, err := InterfaceAddrs()
 	if err != nil {
 		mod.log.Errorv(0, "network interface monitoring disabled: %v", err)
 		return
@@ -123,7 +123,7 @@ func (mod *Module) watchAddresses(ctx context.Context) {
 }
 
 func (mod *Module) getAddresses() (s []string) {
-	addrs, _ := net.InterfaceAddrs()
+	addrs, _ := InterfaceAddrs()
 	for _, addr := range addrs {
 		s = append(s, addr.String())
 	}

--- a/mod/tcp/src/net.go
+++ b/mod/tcp/src/net.go
@@ -1,0 +1,5 @@
+package tcp
+
+import "net"
+
+var InterfaceAddrs = net.InterfaceAddrs


### PR DESCRIPTION
Allows to bypass net.Interfaces and net.InterfaceAddrs on mobile platforms