### PR TITLE
config: add omitempty to core.Config and apphost.Config

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -3,15 +3,15 @@ package core
 const configName = "node"
 
 type Config struct {
-	Identity        string   `yaml:"identity"`
-	Modules         []string `yaml:"modules"`
-	LogRoutingStart bool     `yaml:"log_routing_start"`
-	Log             LogConfig
+	Identity        string    `yaml:"identity,omitempty"`
+	Modules         []string  `yaml:"modules,omitempty"`
+	LogRoutingStart bool      `yaml:"log_routing_start,omitempty"`
+	Log             LogConfig `yaml:"log,omitempty"`
 }
 
 type LogConfig struct {
-	Level         int  `yaml:"level"`
-	DisableColors bool `yaml:"disable_colors"`
+	Level         int  `yaml:"level,omitempty"`
+	DisableColors bool `yaml:"disable_colors,omitempty"`
 }
 
 var defaultConfig = Config{}

--- a/mod/apphost/src/config.go
+++ b/mod/apphost/src/config.go
@@ -1,21 +1,21 @@
 package apphost
 
 type ObjectServerConfig struct {
-	Bind []string `yaml:"bind"`
+	Bind []string `yaml:"bind,omitempty"`
 }
 
 type Config struct {
 	// Listen on these adresses
-	Listen []string `yaml:"listen"`
+	Listen []string `yaml:"listen,omitempty"`
 
 	// Number of apphost workers
-	Workers int `yaml:"workers"`
+	Workers int `yaml:"workers,omitempty"`
 
-	Tokens map[string]string `yaml:"tokens"`
+	Tokens map[string]string `yaml:"tokens,omitempty"`
 
-	ObjectServer ObjectServerConfig `yaml:"object_server"`
+	ObjectServer ObjectServerConfig `yaml:"object_server,omitempty"`
 
-	AllowAnonymous bool `yaml:"allow_anonymous"`
+	AllowAnonymous bool `yaml:"allow_anonymous,omitempty"`
 }
 
 var defaultConfig = Config{

--- a/mod/tcp/src/config.go
+++ b/mod/tcp/src/config.go
@@ -3,9 +3,9 @@ package tcp
 import "time"
 
 type Config struct {
-	DialTimeout     time.Duration `yaml:"dial_timeout"`
-	PublicEndpoints []string      `yaml:"public_endpoints"`
-	ListenPort      int           `yaml:"listen_port"`
+	DialTimeout     time.Duration `yaml:"dial_timeout,omitempty"`
+	PublicEndpoints []string      `yaml:"public_endpoints,omitempty"`
+	ListenPort      int           `yaml:"listen_port,omitempty"`
 }
 
 var defaultConfig = Config{


### PR DESCRIPTION
The newest portald implementation needs to read and write astrald configs for environment setup and identity generation purposes. See: https://github.com/cryptopunkscc/portal/blob/dev/core/astrald/apphost.go#L18

This change fixes some nasty bug with loading an empty configuration from the generated config, additionally makes the generated configs looks better.