### PR TITLE
cmd/astrald: move mods.go to mod/

### DIFF
--- a/cmd/astrald/main.go
+++ b/cmd/astrald/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	_ "github.com/cryptopunkscc/astrald/mod"
 )
 
 // Exit statuses

--- a/mod/mods.go
+++ b/mod/mods.go
@@ -1,6 +1,7 @@
-package main
+package mod
 
-// this file includes all modules that should be compiled into the node
+// This file includes all modules that should be compiled into the node.
+// Do not move this file to another package as it is exposed for https://github.com/cryptopunkscc/portal.
 
 import (
 	_ "github.com/cryptopunkscc/astrald/mod/apphost/src"


### PR DESCRIPTION
Exposes mod imports for the android wrapper, to simplify upgrading node version.