### PR TITLE
split config and data directories using XDG spec

### DIFF
--- a/cmd/astrald/args.go
+++ b/cmd/astrald/args.go
@@ -4,43 +4,79 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
 const nodeDirName = "astrald"
 
 type Args struct {
-	NodeRoot string
-	DBRoot   string
-	Ghost    bool
-	Version  bool
+	Root    string
+	Ghost   bool
+	Version bool
 }
 
 func parseArgs() *Args {
-	var args = &Args{
-		NodeRoot: defaultRoot(),
-	}
+	var root string
+	var ghost, version bool
 
-	flag.StringVar(&args.NodeRoot, "root", args.NodeRoot, "set node's root directory")
-	flag.StringVar(&args.DBRoot, "dbroot", args.NodeRoot, "set database root directory")
-	flag.BoolVar(&args.Ghost, "g", false, "enable ghost mode")
-	flag.BoolVar(&args.Version, "v", false, "show version")
+	flag.StringVar(&root, "root", "", "set node's root directory (config goes to <root>/config, data to <root>/data)")
+	flag.BoolVar(&ghost, "g", false, "enable ghost mode")
+	flag.BoolVar(&version, "v", false, "show version")
 	flag.Parse()
 
-	if strings.HasPrefix(args.NodeRoot, "~/") {
+	args := &Args{
+		Ghost:   ghost,
+		Version: version,
+	}
+
+	if root != "" {
+		args.Root = root
+	}
+
+	if strings.HasPrefix(args.Root, "~/") {
 		if homeDir, err := os.UserHomeDir(); err == nil {
-			args.NodeRoot = filepath.Join(homeDir, args.NodeRoot[2:])
+			args.Root = filepath.Join(homeDir, args.Root[2:])
 		}
 	}
 
 	return args
 }
 
-func defaultRoot() string {
+func userDataDir() (string, error) {
+	// On macOS, there is no XDG-style split — both config and data
+	// live under ~/Library/Application Support. Return the same
+	// directory as os.UserConfigDir() so they coexist.
+	if runtime.GOOS == "darwin" {
+		return os.UserConfigDir()
+	}
+
+	if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
+		return dir, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".local", "share"), nil
+}
+
+func defaultConfigRoot() string {
 	cfgDir, err := os.UserConfigDir()
 	if err != nil {
 		return nodeDirName
 	}
 
-	return filepath.Join(cfgDir, "astrald")
+	return filepath.Join(cfgDir, nodeDirName)
+}
+
+func defaultDataRoot() string {
+	dataDir, err := userDataDir()
+	if err != nil {
+		return filepath.Join(os.Getenv("HOME"), nodeDirName)
+	}
+
+	return filepath.Join(dataDir, nodeDirName)
 }

--- a/cmd/astrald/args.go
+++ b/cmd/astrald/args.go
@@ -44,10 +44,10 @@ func parseArgs() *Args {
 }
 
 func userDataDir() (string, error) {
-	// On macOS, there is no XDG-style split — both config and data
-	// live under ~/Library/Application Support. Return the same
-	// directory as os.UserConfigDir() so they coexist.
-	if runtime.GOOS == "darwin" {
+	// On macOS and Windows, there is no XDG-style split between config
+	// and data — both live under the platform's config directory.
+	// Only Linux uses separate XDG_CONFIG_HOME and XDG_DATA_HOME.
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		return os.UserConfigDir()
 	}
 

--- a/cmd/astrald/run.go
+++ b/cmd/astrald/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/cryptopunkscc/astrald/core"
@@ -40,23 +41,35 @@ func setupResources(args *Args) (resources.Resources, error) {
 		return mem, nil
 	}
 
-	nodeRes, err := resources.NewFileResources(args.NodeRoot, true)
+	// derive config and data roots from a single base directory
+	configRoot := defaultConfigRoot()
+	dataRoot := defaultDataRoot()
+
+	if args.Root != "" {
+		configRoot = filepath.Join(args.Root, "config")
+		dataRoot = filepath.Join(args.Root, "data")
+	}
+
+	nodeRes, err := resources.NewFileResources(configRoot, true)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(args.DBRoot) > 0 {
-		nodeRes.SetDatabaseRoot(args.DBRoot)
+	nodeRes.SetDataRoot(dataRoot)
+
+	// make sure root directories exist
+	err = os.MkdirAll(configRoot, 0700)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error creating config directory: %s\n", err)
 	}
 
-	// make sure root directory exists
-	err = os.MkdirAll(args.NodeRoot, 0700)
+	err = os.MkdirAll(dataRoot, 0700)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error creating node directory: %s\n", err)
+		fmt.Fprintf(os.Stderr, "error creating data directory: %s\n", err)
 	}
 
 	// set directory for saving crash logs
-	debug.LogDir = args.NodeRoot
+	debug.LogDir = configRoot
 	defer debug.SaveLog(func(p any) {
 		debug.SigInt(p)
 		time.Sleep(time.Second) // give components time to exit cleanly

--- a/core/assets/core_assets.go
+++ b/core/assets/core_assets.go
@@ -109,7 +109,7 @@ func (assets *CoreAssets) OpenDatabase(name string) (*gorm.DB, error) {
 
 	switch res := assets.res.(type) {
 	case *resources.FileResources:
-		var dbPath = filepath.Join(res.DatabaseRoot(), name)
+		var dbPath = filepath.Join(res.DataRoot(), name)
 
 		return gorm.Open(
 			dbOpen(dbPath),

--- a/mod/fs/src/loader.go
+++ b/mod/fs/src/loader.go
@@ -42,7 +42,7 @@ func (Loader) Load(node astral.Node, assets assets.Assets, log *log.Logger) (cor
 }
 
 func (mod *Module) addDefaultRepo() {
-	// create a repo for the 'data' directory in config dir
+	// create a repo for the 'data' directory in data dir
 	res, ok := mod.assets.Res().(*resources.FileResources)
 	if !ok {
 		return
@@ -54,7 +54,7 @@ func (mod *Module) addDefaultRepo() {
 	}
 
 	// create the directory for the default repository if needed
-	dataPath := filepath.Join(res.Root(), "data")
+	dataPath := filepath.Join(res.DataRoot(), "data")
 
 	err := os.MkdirAll(dataPath, 0700)
 	if err != nil {

--- a/resources/file_resources.go
+++ b/resources/file_resources.go
@@ -12,8 +12,8 @@ import (
 var _ Resources = &FileResources{}
 
 type FileResources struct {
-	root   string
-	dbRoot string
+	root     string
+	dataRoot string
 }
 
 func NewFileResources(root string, mkdir bool) (*FileResources, error) {
@@ -35,8 +35,8 @@ func NewFileResources(root string, mkdir bool) (*FileResources, error) {
 	}, nil
 }
 
-func (res *FileResources) SetDatabaseRoot(rootDb string) {
-	res.dbRoot = rootDb
+func (res *FileResources) SetDataRoot(dataRoot string) {
+	res.dataRoot = dataRoot
 }
 
 func (res *FileResources) Read(name string) ([]byte, error) {
@@ -66,9 +66,9 @@ func (res *FileResources) Root() string {
 	return res.root
 }
 
-func (res *FileResources) DatabaseRoot() string {
-	if len(res.dbRoot) > 0 {
-		return res.dbRoot
+func (res *FileResources) DataRoot() string {
+	if len(res.dataRoot) > 0 {
+		return res.dataRoot
 	}
 
 	return res.Root()


### PR DESCRIPTION
- Add userDataDir() following XDG_DATA_HOME convention
- defaultConfigRoot() -> UserConfigDir/astrald (config files, identity, crash logs)
- defaultDataRoot() -> UserDataDir/astrald (database, default write repo)
- DBRoot flag now defaults to data dir instead of config dir
- FS module default write repo uses DatabaseRoot() instead of Root()
- Remove conditional DBRoot check (always has a default now)