### PR TITLE
streams: doc-comment exported behavioral symbols

### DIFF
--- a/streams/async_writer.go
+++ b/streams/async_writer.go
@@ -8,6 +8,8 @@ import (
 
 var ErrBufferOverflow = errors.New("buffer overflow")
 
+// AsyncWriter buffers writes in memory and flushes them to the underlying WriteCloser in a background goroutine.
+// Writes return immediately as long as buffer capacity is available; they fail with ErrBufferOverflow if not.
 type AsyncWriter struct {
 	writer     io.WriteCloser
 	afterFlush func([]byte)
@@ -21,6 +23,7 @@ type AsyncWriter struct {
 	done       chan struct{}
 }
 
+// NewAsyncWriter creates an AsyncWriter and starts the background flusher goroutine.
 func NewAsyncWriter(output io.WriteCloser, bufferSize int) *AsyncWriter {
 	var w = &AsyncWriter{
 		writer:     output,
@@ -36,6 +39,8 @@ func NewAsyncWriter(output io.WriteCloser, bufferSize int) *AsyncWriter {
 
 }
 
+// Write enqueues p for asynchronous delivery; returns ErrBufferOverflow immediately if buffer space is exhausted.
+// The caller retains ownership of p until AfterFlush fires.
 func (b *AsyncWriter) Write(p []byte) (int, error) {
 	b.cond.L.Lock()
 	defer b.cond.L.Unlock()
@@ -60,6 +65,8 @@ func (b *AsyncWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// Close signals the flusher to stop after draining the current buffer; it does not wait for completion.
+// Use Sync or Done to wait for the flusher to exit.
 func (b *AsyncWriter) Close() error {
 	b.cond.L.Lock()
 	defer b.cond.L.Unlock()
@@ -120,6 +127,7 @@ func (b *AsyncWriter) SetWriter(output io.WriteCloser) {
 	b.writer = output
 }
 
+// Sync blocks until the write buffer is empty or a write error has occurred.
 func (b *AsyncWriter) Sync() error {
 	b.cond.L.Lock()
 	defer b.cond.L.Unlock()
@@ -135,10 +143,12 @@ func (b *AsyncWriter) Sync() error {
 	}
 }
 
+// Done returns a channel that is closed when the flusher goroutine has exited and the underlying writer is closed.
 func (b *AsyncWriter) Done() <-chan struct{} {
 	return b.done
 }
 
+// Err returns the last error from the flusher goroutine without holding the lock; safe to call only after Done is closed.
 func (b *AsyncWriter) Err() error {
 	return b.writeErr
 }

--- a/streams/counter.go
+++ b/streams/counter.go
@@ -26,6 +26,7 @@ type WriteCounter struct {
 	n int64
 }
 
+// NewWriteCounter wraps w in a WriteCounter; if w is nil, writes are discarded and only the total is tracked.
 func NewWriteCounter(w io.Writer) *WriteCounter {
 	if w == nil {
 		w = NilWriter{}

--- a/streams/limited_reader.go
+++ b/streams/limited_reader.go
@@ -4,6 +4,8 @@ import "io"
 
 var _ io.ReadCloser = &LimitedReader{}
 
+// LimitedReader wraps a ReadCloser and returns io.EOF once exactly Limit bytes have been read.
+// Unlike io.LimitedReader, it also propagates Close to the underlying reader.
 type LimitedReader struct {
 	io.ReadCloser
 	Limit uint64

--- a/streams/pipe.go
+++ b/streams/pipe.go
@@ -6,6 +6,8 @@ import (
 
 var _ io.ReadWriteCloser = PipeEnd{}
 
+// PipeEnd is one end of a bidirectional pipe; reading from it consumes data written by the remote end and vice versa.
+// A read or write error on one side automatically closes the opposite direction.
 type PipeEnd struct {
 	r *io.PipeReader
 	w *io.PipeWriter
@@ -25,7 +27,7 @@ func Pipe() (left PipeEnd, right PipeEnd) {
 		}
 }
 
-// io.ErrClosedPipe, io.EOF
+// Read reads from the remote writer's data; closes the local write side on any error so the remote end sees EOF.
 func (pipe PipeEnd) Read(p []byte) (n int, err error) {
 	n, err = pipe.r.Read(p)
 	if err != nil {
@@ -34,6 +36,7 @@ func (pipe PipeEnd) Read(p []byte) (n int, err error) {
 	return
 }
 
+// Write sends data to the remote reader; closes the local read side on any error.
 func (pipe PipeEnd) Write(p []byte) (n int, err error) {
 	n, err = pipe.w.Write(p)
 	if err != nil {

--- a/streams/read_write_all.go
+++ b/streams/read_write_all.go
@@ -2,6 +2,7 @@ package streams
 
 import "io"
 
+// ReadAllFrom reads from r into each target in order, stopping at the first error.
 func ReadAllFrom(r io.Reader, v ...io.ReaderFrom) (n int64, err error) {
 	var m int64
 	for _, i := range v {
@@ -14,6 +15,7 @@ func ReadAllFrom(r io.Reader, v ...io.ReaderFrom) (n int64, err error) {
 	return
 }
 
+// WriteAllTo writes each source to w in order, stopping at the first error.
 func WriteAllTo(w io.Writer, v ...io.WriterTo) (n int64, err error) {
 	var m int64
 	for _, i := range v {

--- a/streams/rwc_split.go
+++ b/streams/rwc_split.go
@@ -2,6 +2,7 @@ package streams
 
 import "io"
 
+// ReadWriteCloseSplit composes independent Reader, Writer, and Closer into a single ReadWriteCloser.
 type ReadWriteCloseSplit struct {
 	io.Reader
 	io.Writer


### PR DESCRIPTION
Add minimal Go doc comments to exported funcs, methods, types and interfaces with non-obvious behavior in the streams package, per .ai/comments.md. Comments-only, no logic changes; symbols whose intent is obvious from their signature were deliberately left uncommented (see the task skip log).