### PR TITLE
core: doc-comment exported behavioral symbols

### DIFF
--- a/core/assets/assets.go
+++ b/core/assets/assets.go
@@ -5,6 +5,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Assets is the contract for node-local storage: raw resources, YAML config, and a shared database handle.
 type Assets interface {
 	Res() resources.Resources
 	Read(name string) ([]byte, error)

--- a/core/assets/core_assets.go
+++ b/core/assets/core_assets.go
@@ -24,6 +24,7 @@ type CoreAssets struct {
 	db  *gorm.DB
 }
 
+// NewCoreAssets opens the default database eagerly; fails if it cannot be reached.
 func NewCoreAssets(res resources.Resources, log *log2.Logger) (*CoreAssets, error) {
 	var err error
 	var a = &CoreAssets{
@@ -51,6 +52,7 @@ func (assets *CoreAssets) Write(name string, data []byte) error {
 	return assets.res.Write(name, data)
 }
 
+// LoadYAML appends a .yaml suffix to name if missing.
 func (assets *CoreAssets) LoadYAML(name string, out interface{}) error {
 	if !strings.HasSuffix(strings.ToLower(name), ".yaml") {
 		name = name + ".yaml"
@@ -64,6 +66,7 @@ func (assets *CoreAssets) LoadYAML(name string, out interface{}) error {
 	return yaml.Unmarshal(bytes, out)
 }
 
+// StoreYAML appends a .yaml suffix to name if missing.
 func (assets *CoreAssets) StoreYAML(name string, in interface{}) error {
 	if !strings.HasSuffix(strings.ToLower(name), ".yaml") {
 		name = name + ".yaml"
@@ -81,6 +84,8 @@ func (assets *CoreAssets) Database() *gorm.DB {
 	return assets.db
 }
 
+// OpenDatabase resolves name to a file path under FileResources or a shared in-memory db under MemResources.
+// Appends a .db suffix if missing; errors when the resource backend supports neither.
 func (assets *CoreAssets) OpenDatabase(name string) (*gorm.DB, error) {
 	if name == "" {
 		return nil, errors.New("invalid name")

--- a/core/errors.go
+++ b/core/errors.go
@@ -17,6 +17,7 @@ func errModuleUnavailable(name string) ErrModuleUnavailable {
 	return ErrModuleUnavailable{Name: name}
 }
 
+// Is matches any ErrModuleUnavailable regardless of module name.
 func (ErrModuleUnavailable) Is(other error) bool {
 	var errModuleUnavailable *ErrModuleUnavailable
 	return errors.As(other, &errModuleUnavailable)

--- a/core/modules.go
+++ b/core/modules.go
@@ -24,10 +24,12 @@ type Modules struct {
 	log     *log2.Logger
 }
 
+// Module runs its services for the lifetime of the context and returns when the context ends.
 type Module interface {
 	Run(*astral.Context) error
 }
 
+// ModuleLoader instantiates a module. Load must not access other modules; load order is undefined.
 type ModuleLoader interface {
 	Load(astral.Node, assets.Assets, *log2.Logger) (Module, error)
 }
@@ -46,6 +48,7 @@ func NewModules(n *Node, mods []string, assets assets.Assets, log *log2.Logger) 
 	return m, nil
 }
 
+// Run drives all enabled modules through the load, dependency, prepare, and run stages in order, then blocks until the context ends.
 func (m *Modules) Run(ctx *astral.Context) error {
 	// Load enabled modules. Loaders should only return a new instance of the module and must not try
 	// to access other modules, as the order of loading is undefined.
@@ -220,6 +223,7 @@ func (m *Modules) Loaded() []Module {
 	return mods
 }
 
+// RegisterModule adds a loader to the global registry; fails if the name is already taken.
 func RegisterModule(name string, loader ModuleLoader) error {
 	if _, ok := modules.Set(name, loader); !ok {
 		return errors.New("module already added")
@@ -228,6 +232,7 @@ func RegisterModule(name string, loader ModuleLoader) error {
 	return nil
 }
 
+// Load returns the named module type-asserted to M, or ErrModuleUnavailable if missing or of the wrong type.
 func Load[M any](node astral.Node, name string) (M, error) {
 	cnode, ok := node.(*Node)
 	if !ok {
@@ -282,10 +287,12 @@ func Inject(node astral.Node, target any) (err error) {
 	return
 }
 
+// DependencyLoader is optionally implemented by modules to resolve dependencies in the dependency stage, before Prepare.
 type DependencyLoader interface {
 	LoadDependencies(ctx *astral.Context) error
 }
 
+// Preparer is optionally implemented by modules to configure themselves in the prepare stage, before Run.
 type Preparer interface {
 	Prepare(context.Context) error
 }

--- a/core/node.go
+++ b/core/node.go
@@ -15,6 +15,7 @@ const logTag = "node"
 
 var _ astral.Node = &Node{}
 
+// Node is the core astral node: identity, config, assets, modules, and the embedded query Router.
 type Node struct {
 	*Router
 	identity *astral.Identity

--- a/core/params.go
+++ b/core/params.go
@@ -126,6 +126,7 @@ func SplitQueryParams(query string) (path, params string) {
 	return query, ""
 }
 
+// ParseParams parses &-separated key=value pairs; an item without '=' becomes a value under the empty key.
 func ParseParams(params string) Params {
 	var p = map[string]string{}
 
@@ -151,6 +152,7 @@ func ParseQuery(query string) (path string, params Params) {
 	return
 }
 
+// Query builds a query string from path and params; param order is non-deterministic.
 func Query(path string, params Params) string {
 	var f = path
 	var l []string

--- a/core/query_modifier.go
+++ b/core/query_modifier.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cryptopunkscc/astrald/sig"
 )
 
+// QueryModifier is handed to preprocessors to inspect and mutate an in-flight query before routing.
 type QueryModifier struct {
 	query   *astral.InFlightQuery
 	blocked sig.Value[error]
@@ -17,6 +18,7 @@ func (q *QueryModifier) Query() *astral.InFlightQuery {
 	return q.query
 }
 
+// Block marks the query as rejected; routing returns RouteNotFound. Only the first block takes effect.
 func (q *QueryModifier) Block(err error) {
 	q.blocked.Swap(nil, err)
 }
@@ -25,6 +27,7 @@ func (q *QueryModifier) Attach(object astral.Object) {
 	q.query.Extra.Set(nodes.ExtraCallerProof, object)
 }
 
+// AddRelay appends a relay identity to the query, skipping duplicates.
 func (q *QueryModifier) AddRelay(identity *astral.Identity) {
 	if l, ok := q.query.Extra.Get(nodes.ExtraRelayVia); ok {
 		if l, ok := l.([]*astral.Identity); ok {

--- a/core/router.go
+++ b/core/router.go
@@ -14,6 +14,7 @@ var _ astral.Router = &Router{}
 
 const routingTimeout = 60 * time.Second
 
+// Router wraps a PriorityRouter, tracking live connections and running query preprocessors around each route.
 type Router struct {
 	node *Node
 	*routing.PriorityRouter
@@ -21,6 +22,7 @@ type Router struct {
 	preprocessors sig.Set[QueryPreprocessor]
 }
 
+// QueryPreprocessor inspects and mutates each query before routing; returning an error or blocking rejects it.
 type QueryPreprocessor interface {
 	PreprocessQuery(*QueryModifier) error
 }
@@ -38,6 +40,7 @@ func (r *Router) AddQueryPreprocessor(f QueryPreprocessor) error {
 	return r.preprocessors.Add(f)
 }
 
+// RouteQuery defaults missing caller/target to this node, runs preprocessors (any block yields RouteNotFound), then routes and logs the outcome.
 func (r *Router) RouteQuery(ctx *astral.Context, q *astral.InFlightQuery, w io.WriteCloser) (target io.WriteCloser, err error) {
 	if q.Caller == nil {
 		q.Caller = r.node.identity


### PR DESCRIPTION
Add minimal Go doc comments to exported funcs, methods, types and interfaces with non-obvious behavior across the core package, per .ai/comments.md. Comments-only, no logic changes; symbols whose intent is obvious from their signature were deliberately left uncommented (see the task skip log).