### PR TITLE
identity: doc-comment exported behavioral symbols

### DIFF
--- a/mod/auth/client/client.go
+++ b/mod/auth/client/client.go
@@ -15,7 +15,6 @@ type Client struct {
 
 var defaultClient *Client
 
-// New creates a Client targeting targetID; a nil astrald.Client falls back to astrald.Default().
 func New(targetID *astral.Identity, a *astrald.Client) *Client {
 	if a == nil {
 		a = astrald.Default()

--- a/mod/auth/client/client.go
+++ b/mod/auth/client/client.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cryptopunkscc/astrald/lib/astrald"
 )
 
+// Client is an RPC client for the auth module.
+// targetID selects the remote node; nil targets the local node.
 type Client struct {
 	astral   *astrald.Client
 	targetID *astral.Identity
@@ -13,6 +15,7 @@ type Client struct {
 
 var defaultClient *Client
 
+// New creates a Client targeting targetID; a nil astrald.Client falls back to astrald.Default().
 func New(targetID *astral.Identity, a *astrald.Client) *Client {
 	if a == nil {
 		a = astrald.Default()

--- a/mod/auth/client/sign_contract.go
+++ b/mod/auth/client/sign_contract.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/auth"
 )
 
+// SignContract submits contract for remote signing; the contract is sent after the channel is
+// established, not as query args.
 func (c *Client) SignContract(ctx *astral.Context, contract *auth.Contract) (*auth.SignedContract, error) {
 	ch, err := c.queryCh(ctx, auth.MethodSignContract, nil)
 	if err != nil {

--- a/mod/auth/contract.go
+++ b/mod/auth/contract.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/crypto"
 )
 
+// Contract is the unsigned body of an authorization grant from Issuer to Subject.
+// Wrap it in SignedContract before indexing or verifying.
 type Contract struct {
 	Issuer  *astral.Identity
 	Subject *astral.Identity
@@ -32,6 +34,8 @@ func (p *Permit) ReadFrom(r io.Reader) (int64, error) { return astral.Objectify(
 func (p Permit) MarshalJSON() ([]byte, error)  { return astral.Objectify(&p).MarshalJSON() }
 func (p *Permit) UnmarshalJSON(b []byte) error { return astral.Objectify(p).UnmarshalJSON(b) }
 
+// Allows reports whether any permit in the contract matches the action.
+// Actions not implementing Constrainable pass constraint checks automatically.
 func (c *Contract) Allows(action ActionObject) bool {
 	if c.Permits == nil {
 		return false

--- a/mod/auth/module.go
+++ b/mod/auth/module.go
@@ -12,6 +12,8 @@ const (
 	MethodSignContract = "auth.sign_contract"
 )
 
+// ContractQueryBuilder builds and executes queries for active signed contracts.
+// Filters are cumulative; call Find to execute.
 type ContractQueryBuilder interface {
 	WithIssuer(*astral.Identity) ContractQueryBuilder
 	WithSubject(*astral.Identity) ContractQueryBuilder

--- a/mod/auth/signed_contract.go
+++ b/mod/auth/signed_contract.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/crypto"
 )
 
+// SignedContract pairs a Contract body with the issuer and subject signatures.
+// Either signature field may be nil before the signing step is complete.
 type SignedContract struct {
 	*Contract
 	IssuerSig  *crypto.Signature
@@ -23,6 +25,7 @@ func (c *SignedContract) ReadFrom(r io.Reader) (int64, error) { return astral.Ob
 func (c SignedContract) MarshalJSON() ([]byte, error)  { return astral.Objectify(&c).MarshalJSON() }
 func (c *SignedContract) UnmarshalJSON(b []byte) error { return astral.Objectify(c).UnmarshalJSON(b) }
 
+// IsNil guards against both a nil receiver and an embedded nil *Contract.
 func (c *SignedContract) IsNil() bool { return c == nil || c.Contract == nil }
 
 func init() { _ = astral.Add(&SignedContract{}) }

--- a/mod/auth/src/contracts.go
+++ b/mod/auth/src/contracts.go
@@ -9,6 +9,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/objects"
 )
 
+// IndexContract verifies and stores sc in the local DB; skips silently if already indexed.
+// Callers must hold no locks — the method acquires indexMu internally.
 func (mod *Module) IndexContract(ctx *astral.Context, sc *auth.SignedContract) error {
 	mod.indexMu.Lock()
 	defer mod.indexMu.Unlock()

--- a/mod/auth/src/loader.go
+++ b/mod/auth/src/loader.go
@@ -10,6 +10,8 @@ import (
 
 type Loader struct{}
 
+// Load constructs and wires the auth module: reads config, registers the sudo handler,
+// opens the DB, and runs AutoMigrate before returning the module to the core runtime.
 func (Loader) Load(node astral.Node, assets assets.Assets, log *log.Logger) (core.Module, error) {
 	var err error
 	var mod = &Module{

--- a/mod/auth/src/module.go
+++ b/mod/auth/src/module.go
@@ -13,6 +13,8 @@ import (
 
 var _ auth.Module = &Module{}
 
+// Module is the runtime implementation of auth.Module; it owns the contract DB,
+// the per-action-type handler registry, and the background contract indexer.
 type Module struct {
 	Deps
 	config   Config
@@ -33,6 +35,7 @@ func (mod *Module) String() string {
 	return auth.ModuleName
 }
 
+// Run starts the background contract indexer and blocks until the context is cancelled.
 func (mod *Module) Run(ctx *astral.Context) error {
 	go mod.indexer(ctx)
 	<-ctx.Done()

--- a/mod/auth/src/module.go
+++ b/mod/auth/src/module.go
@@ -13,8 +13,6 @@ import (
 
 var _ auth.Module = &Module{}
 
-// Module is the runtime implementation of auth.Module; it owns the contract DB,
-// the per-action-type handler registry, and the background contract indexer.
 type Module struct {
 	Deps
 	config   Config
@@ -35,7 +33,6 @@ func (mod *Module) String() string {
 	return auth.ModuleName
 }
 
-// Run starts the background contract indexer and blocks until the context is cancelled.
 func (mod *Module) Run(ctx *astral.Context) error {
 	go mod.indexer(ctx)
 	<-ctx.Done()

--- a/mod/auth/src/object_holder.go
+++ b/mod/auth/src/object_holder.go
@@ -7,6 +7,8 @@ import (
 
 var _ objects.Holder = &Module{}
 
+// HoldObject reports whether the object is referenced by an active contract.
+// Returns true on DB error to avoid premature eviction of live contract data.
 func (mod *Module) HoldObject(objectID *astral.ObjectID) bool {
 	held, err := mod.db.activeContractExists(objectID)
 	if err != nil {

--- a/mod/auth/src/op_index.go
+++ b/mod/auth/src/op_index.go
@@ -13,6 +13,8 @@ type opIndexArgs struct {
 	Out string           `query:"optional"`
 }
 
+// OpIndex handles the index remote operation: loads a SignedContract by object ID and
+// indexes it into the local DB, responding with Ack on success or an error frame.
 func (mod *Module) OpIndex(ctx *astral.Context, q *routing.IncomingQuery, args opIndexArgs) error {
 	ch := q.Accept(channel.WithFormats(args.In, args.Out))
 	defer ch.Close()

--- a/mod/auth/src/op_sign_contract.go
+++ b/mod/auth/src/op_sign_contract.go
@@ -12,6 +12,8 @@ type opSignContractArgs struct {
 	Out string `query:"optional"`
 }
 
+// OpSignContract handles the sign-contract remote operation: reads a Contract from the
+// channel, signs it as the local node, and writes the resulting SignedContract back.
 func (mod *Module) OpSignContract(ctx *astral.Context, q *routing.IncomingQuery, args opSignContractArgs) error {
 	ch := q.Accept(channel.WithFormats(args.In, args.Out))
 	defer ch.Close()

--- a/mod/auth/src/signing.go
+++ b/mod/auth/src/signing.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/secp256k1"
 )
 
+// SignIssuer signs the contract as the issuer; returns auth.ErrAlreadySigned if IssuerSig is already set.
 func (mod *Module) SignIssuer(ctx *astral.Context, signed *auth.SignedContract) (*crypto.Signature, error) {
 	if signed.IssuerSig != nil {
 		return nil, auth.ErrAlreadySigned
@@ -22,6 +23,7 @@ func (mod *Module) SignIssuer(ctx *astral.Context, signed *auth.SignedContract) 
 	return sig, nil
 }
 
+// SignSubject signs the contract as the subject; returns auth.ErrAlreadySigned if SubjectSig is already set.
 func (mod *Module) SignSubject(ctx *astral.Context, signed *auth.SignedContract) (*crypto.Signature, error) {
 	if signed.SubjectSig != nil {
 		return nil, auth.ErrAlreadySigned
@@ -60,6 +62,7 @@ func (mod *Module) signAs(ctx *astral.Context, key *crypto.PublicKey, c *auth.Co
 	return nil, fmt.Errorf("no signing scheme available for key %v", key)
 }
 
+// VerifyIssuer checks that IssuerSig is present and cryptographically valid for the contract.
 func (mod *Module) VerifyIssuer(sc *auth.SignedContract) error {
 	if sc.IssuerSig == nil {
 		return errors.New("issuer signature is missing")
@@ -70,6 +73,7 @@ func (mod *Module) VerifyIssuer(sc *auth.SignedContract) error {
 	return nil
 }
 
+// VerifySubject checks that SubjectSig is present and cryptographically valid for the contract.
 func (mod *Module) VerifySubject(sc *auth.SignedContract) error {
 	if sc.SubjectSig == nil {
 		return errors.New("subject signature is missing")

--- a/mod/dir/client/apply_filters.go
+++ b/mod/dir/client/apply_filters.go
@@ -13,6 +13,8 @@ func ApplyFilters(ctx *astral.Context, identity *astral.Identity, filters ...str
 	return Default().ApplyFilters(ctx, identity, filters...)
 }
 
+// ApplyFilters tests identity against the named server-side filters and returns
+// true if the identity matches all of them.
 func (client *Client) ApplyFilters(ctx *astral.Context, identity *astral.Identity, filters ...string) (bool, error) {
 	ch, err := client.queryCh(ctx, dir.MethodSetAlias, query.Args{
 		"id":      identity,

--- a/mod/dir/client/client.go
+++ b/mod/dir/client/client.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cryptopunkscc/astrald/sig"
 )
 
+// Client is a dir module RPC client; when EnableCache is true, resolved identities
+// and aliases are memoized for the lifetime of the client.
 type Client struct {
 	EnableCache  bool
 	targetID     *astral.Identity

--- a/mod/dir/client/get_alias.go
+++ b/mod/dir/client/get_alias.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/dir"
 )
 
+// GetAlias returns the human-readable alias for the given identity, consulting the
+// in-memory cache before making a remote query when EnableCache is set.
 func (client *Client) GetAlias(ctx *astral.Context, identity *astral.Identity) (alias string, err error) {
 	// check cache
 	if client.EnableCache {

--- a/mod/dir/client/resolve_identity.go
+++ b/mod/dir/client/resolve_identity.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/dir"
 )
 
+// ResolveIdentity resolves a name to an Identity: tries direct public-key parse first,
+// then the in-memory cache (when EnableCache is set), then the remote dir resolver.
 func (client *Client) ResolveIdentity(ctx *astral.Context, name string) (identity *astral.Identity, err error) {
 	// try to parse the public key first
 	if id, err := astral.ParseIdentity(name); err == nil {

--- a/mod/dir/module.go
+++ b/mod/dir/module.go
@@ -16,11 +16,16 @@ const (
 	MethodSetAlias     = "dir.set_alias"
 )
 
+// Module is the directory service: it maps identities to human-readable aliases,
+// resolves names to identities, and applies named identity filters.
 type Module interface {
 	SetAlias(*astral.Identity, string) error
 	GetAlias(*astral.Identity) (string, error)
 	ResolveIdentity(string) (*astral.Identity, error)
+	// DisplayName returns the best available human-readable name for the identity,
+	// falling back to a default representation when no alias is set.
 	DisplayName(*astral.Identity) string
+	// AddResolver registers an additional resolver consulted during identity lookups.
 	AddResolver(Resolver) error
 
 	// SetFilter sets a function for a named filter
@@ -42,6 +47,7 @@ type Module interface {
 	ApplyFilters(identity *astral.Identity, filter ...string) bool
 }
 
+// Resolver is implemented by any source that can map names to identities or supply display names.
 type Resolver interface {
 	ResolveIdentity(string) (*astral.Identity, error)
 	DisplayName(*astral.Identity) string

--- a/mod/dir/src/dns.go
+++ b/mod/dir/src/dns.go
@@ -12,6 +12,7 @@ import (
 var domainRegex = regexp.MustCompile(`^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`)
 var _ dir.Resolver = &DNS{}
 
+// DNS resolves identities from DNS TXT records published under the _astral.<domain> subdomain.
 type DNS struct {
 	*Module
 }
@@ -20,6 +21,7 @@ func isValidDomain(domain string) bool {
 	return domainRegex.MatchString(domain)
 }
 
+// ResolveIdentity looks up the identity published in a TXT record at _astral.<s> with the prefix "id=".
 func (dns DNS) ResolveIdentity(s string) (identity *astral.Identity, err error) {
 	if !isValidDomain(s) {
 		return &astral.Identity{}, fmt.Errorf("cannot resolve")
@@ -46,6 +48,7 @@ func (dns DNS) ResolveIdentity(s string) (identity *astral.Identity, err error) 
 	return &astral.Identity{}, fmt.Errorf("cannot resolve")
 }
 
+// DisplayName always returns an empty string; DNS resolution provides no human-readable display names.
 func (dns DNS) DisplayName(identity *astral.Identity) string {
 	return ""
 }

--- a/mod/dir/src/loader.go
+++ b/mod/dir/src/loader.go
@@ -11,6 +11,8 @@ import (
 
 type Loader struct{}
 
+// Load initializes the dir module: migrates the alias DB schema, sets a default node alias if absent,
+// registers the DNS resolver, and installs the built-in "all" and "localnode" identity filters.
 func (Loader) Load(node astral.Node, assets assets.Assets, l *log.Logger) (core.Module, error) {
 	var err error
 	var mod = &Module{

--- a/mod/dir/src/module.go
+++ b/mod/dir/src/module.go
@@ -41,7 +41,6 @@ type Module struct {
 
 var _ dir.Module = &Module{}
 
-// Run blocks until the context is cancelled; this module has no background work of its own.
 func (mod *Module) Run(ctx *astral.Context) error {
 	<-ctx.Done()
 	return nil

--- a/mod/dir/src/module.go
+++ b/mod/dir/src/module.go
@@ -41,6 +41,7 @@ type Module struct {
 
 var _ dir.Module = &Module{}
 
+// Run blocks until the context is cancelled; this module has no background work of its own.
 func (mod *Module) Run(ctx *astral.Context) error {
 	<-ctx.Done()
 	return nil
@@ -50,6 +51,8 @@ func (mod *Module) AddResolver(resolver dir.Resolver) error {
 	return mod.resolvers.Add(resolver)
 }
 
+// ResolveIdentity resolves a name to an identity in priority order: special keywords ("", "anyone", "localnode"),
+// raw identity string, local alias DB, then registered external resolvers.
 func (mod *Module) ResolveIdentity(s string) (identity *astral.Identity, err error) {
 	if s == "" || s == "anyone" {
 		return &astral.Identity{}, nil
@@ -82,6 +85,8 @@ func (mod *Module) ResolveIdentity(s string) (identity *astral.Identity, err err
 	return nil, fmt.Errorf("unknown identity: %s", s)
 }
 
+// DisplayName returns a human-readable name for an identity, falling back through alias, registered resolvers,
+// and finally the identity fingerprint. Returns ZeroIdentity for the zero value.
 func (mod *Module) DisplayName(identity *astral.Identity) string {
 	if identity.IsZero() {
 		return ZeroIdentity
@@ -122,6 +127,8 @@ func (mod *Module) SetDefaultFilters(filters ...string) {
 	mod.defaultFilters = filters
 }
 
+// ApplyFilters returns true if the identity passes any of the named filters (OR semantics).
+// Unknown filter names are silently skipped.
 func (mod *Module) ApplyFilters(identity *astral.Identity, filter ...string) bool {
 	for _, f := range filter {
 		filter := mod.GetFilter(f)

--- a/mod/dir/src/query_preprocessor.go
+++ b/mod/dir/src/query_preprocessor.go
@@ -5,6 +5,8 @@ import (
 	"github.com/cryptopunkscc/astrald/core"
 )
 
+// PreprocessQuery blocks outgoing queries whose target fails the active directory filters.
+// Queries to the local node are always allowed; filters may be overridden per-query via the "filters" extra key.
 func (mod *Module) PreprocessQuery(m *core.QueryModifier) error {
 	q := m.Query()
 

--- a/mod/dir/src/status_composer.go
+++ b/mod/dir/src/status_composer.go
@@ -7,6 +7,8 @@ import (
 
 var _ nearby.Composer = &Module{}
 
+// ComposeStatus attaches the node's directory alias to the nearby composition when the node is in visible mode.
+// Silent and stealth modes produce no attachment.
 func (mod *Module) ComposeStatus(a nearby.Composition) {
 	switch mod.Nearby.Mode() {
 	case nearby.ModeSilent:

--- a/mod/nearby/module.go
+++ b/mod/nearby/module.go
@@ -8,6 +8,8 @@ const (
 	ModuleName = "nearby"
 )
 
+// Module is the public API of the nearby module; implementations manage broadcast state,
+// status composition, and stealth-mode identity resolution.
 type Module interface {
 	Broadcast() error
 	AddStatusComposer(Composer)
@@ -16,10 +18,12 @@ type Module interface {
 	ResolveStatus(status *StatusMessage) *astral.Identity
 }
 
+// Composer contributes attachments to an outgoing status broadcast.
 type Composer interface {
 	ComposeStatus(Composition)
 }
 
+// Composition is the mutable context passed to each Composer during a broadcast cycle.
 type Composition interface {
 	Receiver() *astral.Identity
 	Attach(astral.Object) error

--- a/mod/nearby/scan_message.go
+++ b/mod/nearby/scan_message.go
@@ -5,6 +5,7 @@ import (
 	"io"
 )
 
+// ScanMessage is the discovery probe sent to request a status broadcast from nearby nodes.
 type ScanMessage struct{}
 
 // astral

--- a/mod/nearby/src/composition.go
+++ b/mod/nearby/src/composition.go
@@ -9,6 +9,8 @@ const MaxAttachmentSize = 4 * 1024 // 4 KiB
 
 var _ nearby.Composition = &Composition{}
 
+// Composition is the mutable context passed to each Composer during status construction,
+// scoping attachments to a specific receiver and enforcing the size limit.
 type Composition struct {
 	receiver *astral.Identity
 	s        *nearby.StatusMessage
@@ -18,6 +20,8 @@ func (c *Composition) Receiver() *astral.Identity {
 	return c.receiver
 }
 
+// Attach appends an object to the status message, rejecting it if its serialized
+// size exceeds MaxAttachmentSize.
 func (c *Composition) Attach(o astral.Object) error {
 	objectID, _ := astral.ResolveObjectID(o)
 	if objectID.Size > MaxAttachmentSize {

--- a/mod/nearby/src/deps.go
+++ b/mod/nearby/src/deps.go
@@ -32,9 +32,6 @@ type Deps struct {
 	Tree    tree.Module
 }
 
-// LoadDependencies injects module deps, binds the mode setting to the config tree,
-// registers this module as a dir and nodes resolver, and auto-discovers any loaded
-// module that implements nearby.Composer to receive status-composition callbacks.
 func (mod *Module) LoadDependencies(ctx *astral.Context) (err error) {
 	err = core.Inject(mod.node, &mod.Deps)
 	if err != nil {

--- a/mod/nearby/src/deps.go
+++ b/mod/nearby/src/deps.go
@@ -32,6 +32,9 @@ type Deps struct {
 	Tree    tree.Module
 }
 
+// LoadDependencies injects module deps, binds the mode setting to the config tree,
+// registers this module as a dir and nodes resolver, and auto-discovers any loaded
+// module that implements nearby.Composer to receive status-composition callbacks.
 func (mod *Module) LoadDependencies(ctx *astral.Context) (err error) {
 	err = core.Inject(mod.node, &mod.Deps)
 	if err != nil {

--- a/mod/nearby/src/endpoint_resolver.go
+++ b/mod/nearby/src/endpoint_resolver.go
@@ -8,6 +8,8 @@ import (
 
 var _ nodes.EndpointResolver = &Module{}
 
+// ResolveEndpoints returns endpoints for a node by scanning cached nearby status messages
+// for EndpointWithTTL attachments that match the given identity.
 func (mod *Module) ResolveEndpoints(ctx *astral.Context, nodeID *astral.Identity) (_ <-chan *nodes.EndpointWithTTL, err error) {
 	var list []*nodes.EndpointWithTTL
 

--- a/mod/nearby/src/identity_resolver.go
+++ b/mod/nearby/src/identity_resolver.go
@@ -10,6 +10,9 @@ import (
 
 var _ dir.Resolver = &Module{}
 
+// ResolveIdentity resolves a dot-prefixed alias (e.g. ".phone") by scanning the
+// nearby cache for a matching dir.Alias attachment; returns an error if no peer
+// has announced that alias or the prefix is absent.
 func (mod *Module) ResolveIdentity(s string) (*astral.Identity, error) {
 	s, found := strings.CutPrefix(s, aliasPrefix)
 	if !found {

--- a/mod/nearby/src/module.go
+++ b/mod/nearby/src/module.go
@@ -17,9 +17,6 @@ var _ nearby.Module = &Module{}
 
 const statusExpiration = 5 * time.Minute
 
-// Module implements the nearby protocol: it broadcasts the local node's status over
-// the ether layer, caches peer status messages, and resolves peer identities and
-// endpoints from those caches.
 type Module struct {
 	Deps
 	node   astral.Node
@@ -50,9 +47,6 @@ func (c *cache) GetIdentity() *astral.Identity {
 	return profile[0].NodeID
 }
 
-// Run blocks until ctx is cancelled; it waits for the user identity to be ready,
-// applies the configured mode, then drives periodic status broadcasts and an
-// initial network scan in the background.
 func (mod *Module) Run(ctx *astral.Context) (err error) {
 	mod.ctx = ctx
 

--- a/mod/nearby/src/module.go
+++ b/mod/nearby/src/module.go
@@ -17,6 +17,9 @@ var _ nearby.Module = &Module{}
 
 const statusExpiration = 5 * time.Minute
 
+// Module implements the nearby protocol: it broadcasts the local node's status over
+// the ether layer, caches peer status messages, and resolves peer identities and
+// endpoints from those caches.
 type Module struct {
 	Deps
 	node   astral.Node
@@ -47,6 +50,9 @@ func (c *cache) GetIdentity() *astral.Identity {
 	return profile[0].NodeID
 }
 
+// Run blocks until ctx is cancelled; it waits for the user identity to be ready,
+// applies the configured mode, then drives periodic status broadcasts and an
+// initial network scan in the background.
 func (mod *Module) Run(ctx *astral.Context) (err error) {
 	mod.ctx = ctx
 
@@ -82,6 +88,8 @@ func (mod *Module) AddStatusComposer(composer nearby.Composer) {
 	mod.composers.Add(composer)
 }
 
+// Mode returns the current broadcast mode; falls back to ModeVisible when no user
+// identity is set (node is unowned), and to ModeStealth when the mode is unset.
 func (mod *Module) Mode() nearby.Mode {
 	if mod.User.Identity() == nil {
 		return nearby.ModeVisible
@@ -98,6 +106,7 @@ func (mod *Module) SetMode(ctx *astral.Context, m nearby.Mode) error {
 	return mod.mode.Set(ctx, &m)
 }
 
+// Cache returns the live peer-status map after evicting entries older than statusExpiration.
 func (mod *Module) Cache() *sig.Map[string, *cache] {
 	mod.expireCache()
 	return &mod.cache
@@ -142,6 +151,8 @@ func (mod *Module) periodicUpdater(ctx *astral.Context) {
 	}
 }
 
+// Broadcast pushes the current status to all reachable peers; no-ops silently in
+// ModeSilent without returning an error.
 func (mod *Module) Broadcast() error {
 	if mod.Mode() == nearby.ModeSilent {
 		return nil
@@ -164,6 +175,8 @@ func (mod *Module) canBroadcast(s *nearby.StatusMessage) bool {
 	return mod.Mode() != nearby.ModeStealth || len(s.Attachments.Objects()) > 0
 }
 
+// Status assembles a StatusMessage by invoking every registered Composer; pass nil
+// to address the message to astral.Anyone (broadcast semantics).
 func (mod *Module) Status(receiver *astral.Identity) *nearby.StatusMessage {
 	s := &nearby.StatusMessage{
 		Attachments: astral.NewBundle(),

--- a/mod/nearby/src/object_receiver.go
+++ b/mod/nearby/src/object_receiver.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/objects"
 )
 
+// ReceiveObject handles ether broadcast and network-change events; it silently
+// ignores drops that did not originate from the local node.
 func (mod *Module) ReceiveObject(drop objects.Drop) error {
 	// only receive objects from the local node
 	if !drop.SenderID().IsEqual(mod.node.Identity()) {

--- a/mod/nearby/src/resolve_status.go
+++ b/mod/nearby/src/resolve_status.go
@@ -8,6 +8,9 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/nearby"
 )
 
+// ResolveStatus extracts the sender identity from a StatusMessage using three strategies
+// in priority order: visible mode (PublicProfile or SignedContract attachment), then
+// stealth mode (commitment verification and XOR-unmasking against the local user identity).
 func (mod *Module) ResolveStatus(status *nearby.StatusMessage) *astral.Identity {
 	// visible mode: identity from signed contract
 	if c, ok := astral.First[*nearby.PublicProfile](status.Attachments.Objects()); ok {

--- a/mod/nearby/status.go
+++ b/mod/nearby/status.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cryptopunkscc/astrald/astral"
 )
 
+// Status is a resolved broadcast: the sender's identity has been determined and is paired
+// with the attachment bundle it carried.
 type Status struct {
 	Identity    *astral.Identity
 	Attachments *astral.Bundle

--- a/mod/nearby/status_message.go
+++ b/mod/nearby/status_message.go
@@ -6,6 +6,8 @@ import (
 	"github.com/cryptopunkscc/astrald/astral"
 )
 
+// StatusMessage is the raw broadcast payload received over the wire; the sender's identity
+// has not yet been resolved (use Module.ResolveStatus for that).
 type StatusMessage struct {
 	Attachments *astral.Bundle
 }

--- a/mod/user/client/client.go
+++ b/mod/user/client/client.go
@@ -24,7 +24,6 @@ func New(targetID *astral.Identity, client *astrald.Client) *Client {
 	}
 }
 
-// Default returns a process-wide singleton Client with a nil target, initialized lazily on first call.
 func Default() *Client {
 	if defaultClient == nil {
 		defaultClient = New(nil, astrald.Default())

--- a/mod/user/client/client.go
+++ b/mod/user/client/client.go
@@ -24,6 +24,7 @@ func New(targetID *astral.Identity, client *astrald.Client) *Client {
 	}
 }
 
+// Default returns a process-wide singleton Client with a nil target, initialized lazily on first call.
 func Default() *Client {
 	if defaultClient == nil {
 		defaultClient = New(nil, astrald.Default())

--- a/mod/user/client/invite.go
+++ b/mod/user/client/invite.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/user"
 )
 
+// Invite submits a signed contract to the remote user node and returns the subject's countersignature.
+// The caller must supply the issuer's signature; the remote signs back as the subject.
 func (client *Client) Invite(ctx *astral.Context, contract *auth.Contract, issuerSig *crypto.Signature) (subjectSig *crypto.Signature, err error) {
 	ch, err := client.queryCh(ctx, user.OpInvite, nil)
 	if err != nil {

--- a/mod/user/client/new_node_contract.go
+++ b/mod/user/client/new_node_contract.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/user"
 )
 
+// NewContract requests a new node-binding contract for the user identified by alias from the remote user module.
 func (client *Client) NewContract(ctx *astral.Context, alias string) (contract *auth.Contract, err error) {
 	ch, err := client.queryCh(ctx, user.OpNewNodeContract, query.Args{"user": alias})
 	if err != nil {

--- a/mod/user/maintain_link_task.go
+++ b/mod/user/maintain_link_task.go
@@ -2,6 +2,8 @@ package user
 
 import "github.com/cryptopunkscc/astrald/mod/scheduler"
 
+// MaintainLinkTask keeps an active link to a remote peer alive; restarts the
+// link when it drops.
 type MaintainLinkTask interface {
 	scheduler.Task
 }

--- a/mod/user/module.go
+++ b/mod/user/module.go
@@ -24,10 +24,16 @@ const (
 )
 
 type Module interface {
+	// Ready returns a channel that is closed once the module has applied the
+	// initial active contract and is fully initialized.
 	Ready() <-chan struct{}
 	Identity() *astral.Identity
+	// LocalSwarm returns the identities of swarm members reachable on this
+	// device, excluding remote-only members.
 	LocalSwarm() (list []*astral.Identity)
 	NewMaintainLinkTask(target *astral.Identity) MaintainLinkTask
 	NewSyncNodesTask(remoteIdentity *astral.Identity) SyncNodesAction
+	// PushToLocalSwarm broadcasts obj to every local swarm member except the
+	// node itself using ctx; delivery is best-effort and failures are silently ignored.
 	PushToLocalSwarm(ctx *astral.Context, obj astral.Object)
 }

--- a/mod/user/src/assets.go
+++ b/mod/user/src/assets.go
@@ -25,6 +25,7 @@ func (mod *Module) AssetsContain(objectID *astral.ObjectID) bool {
 	return mod.db.assetExists(objectID)
 }
 
+// Assets returns all object IDs in the user's asset set that have not been removed.
 func (mod *Module) Assets() []*astral.ObjectID {
 	assets, err := mod.db.Assets()
 	if err != nil {

--- a/mod/user/src/authorizers.go
+++ b/mod/user/src/authorizers.go
@@ -19,6 +19,7 @@ func (mod *Module) AuthorizeRelayFor(ctx *astral.Context, a *nodes.RelayForActio
 	return false
 }
 
+// AuthorizeReadObject grants read access to the user identity itself and to any node in the local swarm.
 func (mod *Module) AuthorizeReadObject(ctx *astral.Context, a *objects.ReadObjectAction) bool {
 	if a.Actor().IsEqual(mod.Identity()) {
 		return true

--- a/mod/user/src/contracts.go
+++ b/mod/user/src/contracts.go
@@ -35,6 +35,7 @@ func (mod *Module) ActiveContract() *auth.SignedContract {
 	return mod.activeContract
 }
 
+// Identity returns the user identity (the issuer of the active contract), not the local node identity.
 func (mod *Module) Identity() *astral.Identity {
 	ac := mod.ActiveContract()
 	if ac == nil {
@@ -96,6 +97,8 @@ func (mod *Module) LocalSwarm() (list []*astral.Identity) {
 	return mod.ActiveNodes(ac.Issuer)
 }
 
+// InviteNode issues a SwarmAccess contract to nodeID, collects the remote node's subject signature, and verifies both before returning.
+// Requires an active contract; the user identity becomes the issuer.
 func (mod *Module) InviteNode(ctx *astral.Context, nodeID *astral.Identity) (signed *auth.SignedContract, err error) {
 	ac := mod.ActiveContract()
 	if ac == nil {

--- a/mod/user/src/db.go
+++ b/mod/user/src/db.go
@@ -21,6 +21,7 @@ func (db *DB) assetExists(objectID *astral.ObjectID) (exists bool) {
 	return
 }
 
+// AssetHeight returns the maximum height across all asset rows, or -1 on query error.
 func (db *DB) AssetHeight() int {
 	var height uint64
 
@@ -45,6 +46,7 @@ func (db *DB) NonceExists(nonce astral.Nonce) (exists bool) {
 	return
 }
 
+// AddAsset inserts a new asset row with a fresh nonce; returns an error if the object already exists unless force is true.
 func (db *DB) AddAsset(objectID *astral.ObjectID, force bool) (nonce astral.Nonce, err error) {
 	if !force && db.assetExists(objectID) {
 		return nonce, errors.New("asset already exists")
@@ -59,6 +61,7 @@ func (db *DB) AddAsset(objectID *astral.ObjectID, force bool) (nonce astral.Nonc
 	}).Error
 }
 
+// AddAssetWithNonce is idempotent: if the nonce already exists it is a no-op, enabling replay-safe replication.
 func (db *DB) AddAssetWithNonce(objectID *astral.ObjectID, nonce astral.Nonce) error {
 	if db.NonceExists(nonce) {
 		return nil
@@ -71,6 +74,7 @@ func (db *DB) AddAssetWithNonce(objectID *astral.ObjectID, nonce astral.Nonce) e
 	}).Error
 }
 
+// RemoveAsset marks all non-removed rows for objectID as removed and advances their height; rows are never deleted.
 func (db *DB) RemoveAsset(objectID *astral.ObjectID) (err error) {
 	var rows []dbAsset
 
@@ -91,6 +95,7 @@ func (db *DB) RemoveAsset(objectID *astral.ObjectID) (err error) {
 	return
 }
 
+// RemoveAssetByNonce marks the row with the given nonce as removed; if the nonce is unknown it upserts a tombstone so that late-arriving adds are suppressed.
 func (db *DB) RemoveAssetByNonce(nonce astral.Nonce, objectID *astral.ObjectID) (err error) {
 	var row dbAsset
 
@@ -119,6 +124,7 @@ func (db *DB) RemoveAssetByNonce(nonce astral.Nonce, objectID *astral.ObjectID) 
 	return db.Save(row).Error
 }
 
+// Assets returns the distinct set of object IDs that have at least one non-removed row.
 func (db *DB) Assets() (assets []*astral.ObjectID, err error) {
 	err = db.
 		Model(&dbAsset{}).

--- a/mod/user/src/deps.go
+++ b/mod/user/src/deps.go
@@ -28,6 +28,7 @@ type Deps struct {
 	Tree      tree.Module
 }
 
+// LoadDependencies injects module dependencies, binds the config tree, registers authorizers, and installs directory filters for localswarm and localuser.
 func (mod *Module) LoadDependencies(ctx *astral.Context) (err error) {
 	err = core.Inject(mod.node, &mod.Deps)
 	if err != nil {

--- a/mod/user/src/deps.go
+++ b/mod/user/src/deps.go
@@ -28,7 +28,6 @@ type Deps struct {
 	Tree      tree.Module
 }
 
-// LoadDependencies injects module dependencies, binds the config tree, registers authorizers, and installs directory filters for localswarm and localuser.
 func (mod *Module) LoadDependencies(ctx *astral.Context) (err error) {
 	err = core.Inject(mod.node, &mod.Deps)
 	if err != nil {

--- a/mod/user/src/maintain_link_task.go
+++ b/mod/user/src/maintain_link_task.go
@@ -36,6 +36,8 @@ func (mod *Module) NewMaintainLinkTask(target *astral.
 
 func (a *MaintainLinkTask) String() string { return "nodes.maintain_link" }
 
+// Run loops forever, attempting to re-establish the link to Target whenever it drops.
+// Retries with exponential backoff up to 15 minutes; exits only when ctx is cancelled.
 func (a *MaintainLinkTask) Run(ctx *astral.Context) error {
 	a.mod.log.Log("starting to maintain link to %v", a.Target)
 	retry, err := sig.NewRetry(time.Second, 15*time.Minute, 2)
@@ -90,6 +92,8 @@ func (a *MaintainLinkTask) Run(ctx *astral.Context) error {
 	}
 }
 
+// ReceiveEvent wakes the reconnect loop when the last link to Target is closed.
+// Ignores events for other identities and partial disconnects (LinkCount != 0).
 func (a *MaintainLinkTask) ReceiveEvent(e *events.Event) {
 	switch typed := e.Data.(type) {
 	case *nodes.LinkClosedEvent:

--- a/mod/user/src/maintain_link_task.go
+++ b/mod/user/src/maintain_link_task.go
@@ -36,8 +36,6 @@ func (mod *Module) NewMaintainLinkTask(target *astral.
 
 func (a *MaintainLinkTask) String() string { return "nodes.maintain_link" }
 
-// Run loops forever, attempting to re-establish the link to Target whenever it drops.
-// Retries with exponential backoff up to 15 minutes; exits only when ctx is cancelled.
 func (a *MaintainLinkTask) Run(ctx *astral.Context) error {
 	a.mod.log.Log("starting to maintain link to %v", a.Target)
 	retry, err := sig.NewRetry(time.Second, 15*time.Minute, 2)

--- a/mod/user/src/module.go
+++ b/mod/user/src/module.go
@@ -28,6 +28,8 @@ type Module struct {
 	sibs sig.Map[string, Sibling]
 }
 
+// Run waits for the scheduler, applies and follows the active contract from config, closes the ready channel, then starts the sibling linker.
+// Blocks until ctx is cancelled.
 func (mod *Module) Run(ctx *astral.Context) error {
 	mod.ctx = ctx.IncludeZone(astral.ZoneNetwork)
 	<-mod.Scheduler.Ready()
@@ -51,6 +53,7 @@ func (mod *Module) Router() astral.Router {
 	return &mod.router
 }
 
+// Ready returns a channel that is closed once Run has applied the initial active contract and is fully initialized.
 func (mod *Module) Ready() <-chan struct{} {
 	return mod.ready
 }

--- a/mod/user/src/module.go
+++ b/mod/user/src/module.go
@@ -28,8 +28,6 @@ type Module struct {
 	sibs sig.Map[string, Sibling]
 }
 
-// Run waits for the scheduler, applies and follows the active contract from config, closes the ready channel, then starts the sibling linker.
-// Blocks until ctx is cancelled.
 func (mod *Module) Run(ctx *astral.Context) error {
 	mod.ctx = ctx.IncludeZone(astral.ZoneNetwork)
 	<-mod.Scheduler.Ready()

--- a/mod/user/src/object_finder.go
+++ b/mod/user/src/object_finder.go
@@ -4,6 +4,8 @@ import (
 	"github.com/cryptopunkscc/astrald/astral"
 )
 
+// FindObject streams the identities of all currently-linked sibling nodes as candidate holders for any object.
+// The object ID is intentionally ignored — every sibling may hold the object.
 func (mod *Module) FindObject(ctx *astral.Context, id *astral.ObjectID) (<-chan *astral.Identity, error) {
 	out := make(chan *astral.Identity)
 	go func() {

--- a/mod/user/src/object_receiver.go
+++ b/mod/user/src/object_receiver.go
@@ -13,6 +13,8 @@ import (
 
 var _ objects.Receiver = &Module{}
 
+// ReceiveObject handles pushed objects: indexes incoming signed contracts and triggers sibling sync on new node-contract arrivals.
+// Accepts a LinkCreatedEvent from a swarm member to kick off endpoint synchronization without persisting the event.
 func (mod *Module) ReceiveObject(drop objects.Drop) (err error) {
 	switch o := drop.Object().(type) {
 	case *auth.SignedContract:

--- a/mod/user/src/op_assets.go
+++ b/mod/user/src/op_assets.go
@@ -10,6 +10,8 @@ type opAssetsArgs struct {
 	Out string `query:"optional"`
 }
 
+// OpAssets streams all module assets to the caller, terminating with EOS.
+// On send failure it attempts to deliver an error frame before returning.
 func (mod *Module) OpAssets(ctx *astral.Context, q *routing.IncomingQuery, args opAssetsArgs) (err error) {
 	ch := channel.New(q.AcceptRaw(), channel.WithOutputFormat(args.Out))
 	defer ch.Close()

--- a/mod/user/src/op_claim.go
+++ b/mod/user/src/op_claim.go
@@ -12,6 +12,9 @@ type opClaimArgs struct {
 	Out    string `query:"optional"`
 }
 
+// OpClaim invites a target node into the active contract and indexes the signed result.
+// Requires an active contract; caller must be the contract issuer (code 3 otherwise).
+// Pushes the signed contract to the local swarm asynchronously after indexing.
 func (mod *Module) OpClaim(ctx *astral.Context, q *routing.IncomingQuery, args opClaimArgs) (err error) {
 	// get the active contract
 	ac := mod.ActiveContract()

--- a/mod/user/src/op_info.go
+++ b/mod/user/src/op_info.go
@@ -11,6 +11,8 @@ type opInfoArgs struct {
 	Out string `query:"optional"`
 }
 
+// OpInfo returns identity and contract metadata for this node's active contract.
+// Accessible only to the contract issuer or a current swarm member; rejects all others.
 func (mod *Module) OpInfo(ctx *astral.Context, q *routing.IncomingQuery, args opInfoArgs) (err error) {
 	ac := mod.ActiveContract()
 	if ac == nil {

--- a/mod/user/src/op_invite.go
+++ b/mod/user/src/op_invite.go
@@ -16,6 +16,10 @@ type opInviteArgs struct {
 	Out string `query:"optional"`
 }
 
+// OpInvite handles the node side of the contract signing ceremony.
+// Rejects if an active contract already exists (code 2).
+// Validates contract subject, identity match, and minimum remaining validity before applying the invite policy.
+// On success, stores the signed contract and sets it as the active contract.
 func (mod *Module) OpInvite(ctx *astral.Context, q *routing.IncomingQuery, args opInviteArgs) (err error) {
 	ac := mod.ActiveContract()
 	if ac != nil {

--- a/mod/user/src/op_list_siblings.go
+++ b/mod/user/src/op_list_siblings.go
@@ -11,6 +11,8 @@ type opListSiblingsArgs struct {
 	Zone astral.Zone `query:"optional"`
 }
 
+// OpListSiblings streams the identities of all currently linked sibling nodes.
+// Derives the context from the caller's identity and the requested zone.
 func (mod *Module) OpListSiblings(ctx *astral.Context, q *routing.IncomingQuery, args opListSiblingsArgs) (err error) {
 	ctx, cancel := ctx.WithIdentity(q.Caller()).IncludeZone(args.Zone).WithCancel()
 	defer cancel()

--- a/mod/user/src/op_new_node_contract.go
+++ b/mod/user/src/op_new_node_contract.go
@@ -17,6 +17,9 @@ type opNewNodeContractArgs struct {
 	Out      string `query:"optional"`
 }
 
+// OpNewNodeContract constructs and returns an unsigned node contract.
+// Defaults to the module's own identity for user and the local node identity for node when omitted.
+// note: the contract is not signed or stored; the caller is responsible for the signing ceremony.
 func (mod *Module) OpNewNodeContract(ctx *astral.Context, query *routing.IncomingQuery, args opNewNodeContractArgs) (err error) {
 	ch := query.Accept(channel.WithFormats(args.In, args.Out))
 	defer ch.Close()

--- a/mod/user/src/op_remove_asset.go
+++ b/mod/user/src/op_remove_asset.go
@@ -11,6 +11,8 @@ type opRemoveAssetArgs struct {
 	Out string `query:"optional"`
 }
 
+// OpRemoveAsset removes an asset by object ID.
+// Rejects the query with an internal error code if removal fails, before the channel is accepted.
 func (mod *Module) OpRemoveAsset(ctx *astral.Context, q *routing.IncomingQuery, args opRemoveAssetArgs) (err error) {
 	err = mod.RemoveAsset(args.ID)
 

--- a/mod/user/src/op_request_invite.go
+++ b/mod/user/src/op_request_invite.go
@@ -12,6 +12,9 @@ type opRequestInviteArgs struct {
 	Out string `query:"optional"`
 }
 
+// OpRequestInvite allows a caller node to request membership in this node's swarm.
+// Requires an active contract; applies the swarm join-request policy to the caller before inviting.
+// Pushes the resulting signed contract to the local swarm asynchronously.
 func (mod *Module) OpRequestInvite(ctx *astral.Context, q *routing.IncomingQuery, args opRequestInviteArgs) (err error) {
 	ctx = ctx.IncludeZone(astral.ZoneNetwork)
 

--- a/mod/user/src/op_swarm_status.go
+++ b/mod/user/src/op_swarm_status.go
@@ -12,6 +12,8 @@ type opSwarmStatusArgs struct {
 	Out string `query:"optional"`
 }
 
+// OpSwarmStatus streams the status of every active node in the issuer's swarm.
+// Each entry includes the node identity, its display alias, and whether it is currently linked.
 func (mod *Module) OpSwarmStatus(ctx *astral.Context, q *routing.IncomingQuery, args opSwarmStatusArgs) (err error) {
 	ac := mod.ActiveContract()
 	if ac == nil {

--- a/mod/user/src/op_sync_assets.go
+++ b/mod/user/src/op_sync_assets.go
@@ -13,6 +13,8 @@ type opSyncAssetsArgs struct {
 	Out   string        `query:"optional"`
 }
 
+// OpSyncAssets streams asset delta records from the given DB height and replies with the next unread height.
+// If no rows are found at or above Start, echoes Start as the height so callers can safely re-poll.
 func (mod *Module) OpSyncAssets(ctx *astral.Context, q *routing.IncomingQuery, args opSyncAssetsArgs) (err error) {
 	var rows []*dbAsset
 

--- a/mod/user/src/op_sync_with.go
+++ b/mod/user/src/op_sync_with.go
@@ -12,6 +12,7 @@ type opSyncWithArgs struct {
 	Out   string        `query:"optional"`
 }
 
+// OpSyncWith triggers an outbound asset sync with the specified node over the network zone.
 func (mod *Module) OpSyncWith(ctx *astral.Context, q *routing.IncomingQuery, args opSyncWithArgs) (err error) {
 	ch := channel.New(q.AcceptRaw(), channel.WithOutputFormat(args.Out))
 	defer ch.Close()

--- a/mod/user/src/query_preprocessor.go
+++ b/mod/user/src/query_preprocessor.go
@@ -6,6 +6,9 @@ import (
 
 var _ core.QueryPreprocessor = &Module{}
 
+// PreprocessQuery attaches routing context to outgoing queries based on the active contract.
+// Attaches the active contract to any query whose caller is the issuer.
+// Adds relay nodes: all linked siblings when the target is the issuer; all active nodes otherwise.
 func (mod *Module) PreprocessQuery(qm *core.QueryModifier) error {
 	// get the active contract
 	ac := mod.ActiveContract()

--- a/mod/user/src/search_preprocessor.go
+++ b/mod/user/src/search_preprocessor.go
@@ -2,6 +2,7 @@ package user
 
 import "github.com/cryptopunkscc/astrald/mod/objects"
 
+// PreprocessSearch injects linked siblings as additional search sources when the caller is the active contract issuer.
 func (mod *Module) PreprocessSearch(search *objects.Search) {
 	ac := mod.ActiveContract()
 	if ac == nil {

--- a/mod/user/src/siblings.go
+++ b/mod/user/src/siblings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/user"
 )
 
+// Sibling tracks a connected peer node that shares the same active contract (user).
+// Cancel terminates the background goroutine that maintains the sibling link.
 type Sibling struct {
 	ID     *astral.Identity
 	Cancel context.CancelFunc

--- a/mod/user/src/status_composer.go
+++ b/mod/user/src/status_composer.go
@@ -7,6 +7,10 @@ import (
 
 var _ nearby.Composer = &Module{}
 
+// ComposeStatus attaches identity claims to a nearby composition based on the active mode.
+// In Visible mode, attaches the active contract or a claimable flag with a public profile.
+// In Stealth mode, attaches a StealthHint only when an active contract exists; emits nothing otherwise.
+// In Silent mode, does nothing.
 func (mod *Module) ComposeStatus(a nearby.Composition) {
 	switch mod.Nearby.Mode() {
 	case nearby.ModeSilent:

--- a/mod/user/src/sync.go
+++ b/mod/user/src/sync.go
@@ -159,6 +159,7 @@ func (mod *Module) pushActiveContract(ctx *astral.Context, remoteIdentity *astra
 	mod.Objects.Push(ctx, remoteIdentity, contract)
 }
 
+// PushToLocalSwarm broadcasts obj to every member of the local swarm except the node itself.
 func (mod *Module) PushToLocalSwarm(ctx *astral.Context, obj astral.Object) {
 	for _, sib := range mod.LocalSwarm() {
 		if sib.IsEqual(mod.node.Identity()) {

--- a/mod/user/src/sync_nodes_action.go
+++ b/mod/user/src/sync_nodes_action.go
@@ -5,6 +5,8 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/user"
 )
 
+// SyncNodesAction performs a full sync sequence with a single remote node:
+// alias, active contract, sibling contracts, app contracts, and asset updates.
 type SyncNodesAction struct {
 	remoteIdentity *astral.Identity
 	mod            *Module
@@ -22,6 +24,10 @@ func (a *SyncNodesAction) String() string {
 	return "user.sync_nodes_action"
 }
 
+// Run executes the sync sequence against the remote identity in network zone order:
+// alias pull, active contract push, sibling contract push, app contract push, asset sync.
+// Errors from individual steps are logged but do not abort the remaining steps;
+// syncAssets errors are logged and swallowed — Run always returns nil.
 func (a *SyncNodesAction) Run(ctx *astral.Context) error {
 	ctx = ctx.IncludeZone(astral.ZoneNetwork)
 

--- a/mod/user/swarm_access_action.go
+++ b/mod/user/swarm_access_action.go
@@ -7,6 +7,9 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/auth"
 )
 
+// SwarmAccessAction is the permit type embedded in node contracts; its
+// ObjectType string is what IsNodeContract checks to identify a valid swarm
+// membership contract.
 type SwarmAccessAction struct {
 	auth.Action
 }

--- a/mod/user/swarm_join_policy.go
+++ b/mod/user/swarm_join_policy.go
@@ -5,5 +5,10 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/auth"
 )
 
+// SwarmJoinRequestPolicy decides whether to accept an unsolicited join request
+// from requester; return true to allow, false to decline.
 type SwarmJoinRequestPolicy func(requester *astral.Identity) bool
+
+// SwarmInvitePolicy decides whether to accept an incoming invitation along
+// with its accompanying contract; return true to join, false to decline.
 type SwarmInvitePolicy func(invitee *astral.Identity, contract *auth.Contract) bool

--- a/mod/user/sync_nodes_action.go
+++ b/mod/user/sync_nodes_action.go
@@ -2,6 +2,8 @@ package user
 
 import "github.com/cryptopunkscc/astrald/mod/scheduler"
 
+// SyncNodesAction reconciles local node membership with a remote identity,
+// exchanging swarm member lists and contracts.
 type SyncNodesAction interface {
 	scheduler.Task
 }


### PR DESCRIPTION
Add minimal Go doc comments to exported funcs, methods, types and interfaces with non-obvious behavior across the user, dir, auth and nearby modules, per .ai/comments.md. Comments-only, no logic changes; symbols whose intent is obvious from their signature were deliberately left uncommented (see the task skip log).