### PR TITLE
Sync full swarm roster to a newly invited node

### DIFF
--- a/mod/user/src/op_claim.go
+++ b/mod/user/src/op_claim.go
@@ -52,6 +52,11 @@ func (mod *Module) OpClaim(ctx *astral.Context, q *routing.IncomingQuery, args o
 
 	go mod.PushToLocalSwarm(mod.ctx, signed)
 
+	// why: PushToLocalSwarm only sends the new contract, leaving the invitee
+	// without the inviter's own and sibling contracts. The LinkCreatedEvent
+	// trigger already fired before indexing, so sync the joined node here.
+	mod.Scheduler.Schedule(mod.NewSyncNodesTask(signed.Subject))
+
 	mod.log.Info("signed contract with %v", nodeID)
 	return ch.Send(signed)
 }

--- a/mod/user/src/op_request_invite.go
+++ b/mod/user/src/op_request_invite.go
@@ -51,5 +51,10 @@ func (mod *Module) OpRequestInvite(ctx *astral.Context, q *routing.IncomingQuery
 
 	go mod.PushToLocalSwarm(mod.ctx, signed)
 
+	// why: PushToLocalSwarm only sends the new contract, leaving the invitee
+	// without the inviter's own and sibling contracts. The LinkCreatedEvent
+	// trigger already fired before indexing, so sync the joined node here.
+	mod.Scheduler.Schedule(mod.NewSyncNodesTask(signed.Subject))
+
 	return ch.Send(signed)
 }


### PR DESCRIPTION
The invite path broadcasts only the freshly-signed contract via PushToLocalSwarm, so the invitee receives its own User->node contract but never the inviter's own or sibling contracts. SyncNodesAction would push them, but its only trigger (LinkCount==1) fires before the new contract is indexed, so the joined node is not yet a swarm member and the sync is never scheduled. The link then stays up, so the one-shot edge never repeats and a clean single-session swarm never converges.

Schedule SyncNodesAction against the joined node right after indexing in both invite paths (OpClaim, OpRequestInvite). This pushes the inviter's active contract and all sibling contracts, so the invitee converges to the full, symmetric roster.