### PR TITLE
mod/user: add node expulsion (identity-level swarm ban)

### DIFF
--- a/mod/auth/src/signing.go
+++ b/mod/auth/src/signing.go
@@ -47,19 +47,7 @@ func (mod *Module) SignContract(ctx *astral.Context, signed *auth.SignedContract
 }
 
 func (mod *Module) signAs(ctx *astral.Context, key *crypto.PublicKey, c *auth.Contract) (*crypto.Signature, error) {
-	// todo: We could check what schemas are available for the given key.
-	if signer, err := mod.Crypto.ObjectSigner(key); err == nil {
-		sig, err := signer.SignObject(ctx, c)
-		if err == nil {
-			return sig, nil
-		}
-	}
-
-	if signer, err := mod.Crypto.TextObjectSigner(key); err == nil {
-		return signer.SignTextObject(ctx, c)
-	}
-
-	return nil, fmt.Errorf("no signing scheme available for key %v", key)
+	return mod.Crypto.Sign(ctx, key, c)
 }
 
 // VerifyIssuer checks that IssuerSig is present and cryptographically valid for the contract.
@@ -92,12 +80,5 @@ func (mod *Module) VerifyContract(sc *auth.SignedContract) error {
 }
 
 func (mod *Module) verifySig(key *crypto.PublicKey, sig *crypto.Signature, contract *auth.Contract) error {
-	switch sig.Scheme {
-	case crypto.SchemeASN1:
-		return mod.Crypto.VerifyObjectSignature(key, sig, contract)
-	case crypto.SchemeBIP137:
-		return mod.Crypto.VerifyTextObjectSignature(key, sig, contract)
-	default:
-		return fmt.Errorf("unsupported signature scheme: %s", sig.Scheme)
-	}
+	return mod.Crypto.Verify(key, sig, contract)
 }

--- a/mod/crypto/module.go
+++ b/mod/crypto/module.go
@@ -56,6 +56,16 @@ type Module interface {
 
 	VerifyTextObjectSignature(*PublicKey, *Signature, SignableTextObject) error
 
+	// Sign signs obj as key, selecting a scheme the key supports: it prefers an
+	// object (hash/ASN1) signature and falls back to a text (BIP-137) signature.
+	// A convenience over ObjectSigner/TextObjectSigner so callers signing their
+	// own wire objects need not repeat the scheme-selection dance.
+	Sign(ctx *astral.Context, key *PublicKey, obj SignableTextObject) (*Signature, error)
+
+	// Verify checks sig against obj using key, dispatching on the signature's
+	// scheme. It is the counterpart to Sign.
+	Verify(key *PublicKey, sig *Signature, obj SignableTextObject) error
+
 	AddToIndex(object astral.Object) error
 }
 

--- a/mod/crypto/src/module.go
+++ b/mod/crypto/src/module.go
@@ -218,6 +218,39 @@ func (mod *Module) formatSignableText(object crypto.SignableTextObject) string {
 	return fmt.Sprintf("[%s] %s", commitment, object.SignableText())
 }
 
+// Sign signs obj as key, preferring an object (hash) signature and falling back
+// to a text signature when no object-signing engine is available for the key.
+func (mod *Module) Sign(ctx *astral.Context, key *crypto.PublicKey, obj crypto.SignableTextObject) (*crypto.Signature, error) {
+	if signer, err := mod.ObjectSigner(key); err == nil {
+		sig, err := signer.SignObject(ctx, obj)
+		if err == nil {
+			return sig, nil
+		}
+	}
+
+	if signer, err := mod.TextObjectSigner(key); err == nil {
+		return signer.SignTextObject(ctx, obj)
+	}
+
+	return nil, fmt.Errorf("no signing scheme available for key %v", key)
+}
+
+// Verify checks sig against obj using key, dispatching on the signature scheme.
+func (mod *Module) Verify(key *crypto.PublicKey, sig *crypto.Signature, obj crypto.SignableTextObject) error {
+	if sig == nil {
+		return errors.New("signature is nil")
+	}
+
+	switch sig.Scheme {
+	case crypto.SchemeASN1:
+		return mod.VerifyObjectSignature(key, sig, obj)
+	case crypto.SchemeBIP137:
+		return mod.VerifyTextObjectSignature(key, sig, obj)
+	default:
+		return fmt.Errorf("unsupported signature scheme: %s", sig.Scheme)
+	}
+}
+
 // indexRepo scans and follows the given repo and attempts to index all private keys it encounters
 func (mod *Module) indexRepo(ctx *astral.Context, repo objects.Repository) error {
 	scan, err := repo.Scan(ctx, true)

--- a/mod/nodes/module.go
+++ b/mod/nodes/module.go
@@ -53,6 +53,9 @@ type Module interface {
 
 	IsLinked(*astral.Identity) bool
 
+	// CloseLinks closes all open links with the given identity.
+	CloseLinks(identity *astral.Identity) error
+
 	NewCreateLinkTask(target *astral.Identity, endpoint exonet.Endpoint) CreateLinkTask
 	NewEnsureLinkTask(target *astral.Identity, strategies []string, networks []string, forceNew bool) EnsureLinkTask
 	NewCleanupEndpointsTask() CleanupEndpointsTask

--- a/mod/nodes/src/module.go
+++ b/mod/nodes/src/module.go
@@ -87,6 +87,17 @@ func (mod *Module) CloseLink(id astral.Nonce) error {
 	return nodes.ErrLinkNotFound
 }
 
+// CloseLinks closes all open links with the given identity.
+func (mod *Module) CloseLinks(identity *astral.Identity) error {
+	for _, s := range mod.linkPool.links.Clone() {
+		if s.RemoteIdentity().IsEqual(identity) {
+			_ = s.CloseWithError(errors.New("node expelled"))
+		}
+	}
+
+	return nil
+}
+
 func (mod *Module) Router() astral.Router {
 	return &mod.router
 }

--- a/mod/user/client/expel.go
+++ b/mod/user/client/expel.go
@@ -1,0 +1,21 @@
+package user
+
+import (
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/astral/channel"
+	"github.com/cryptopunkscc/astrald/lib/query"
+	"github.com/cryptopunkscc/astrald/mod/user"
+)
+
+// Expel asks the target user node to permanently ban nodeID from the swarm and
+// returns the signed ban.
+func (client *Client) Expel(ctx *astral.Context, nodeID *astral.Identity) (signed *user.SignedExpulsion, err error) {
+	ch, err := client.queryCh(ctx, user.OpExpel, query.Args{"target": nodeID.String()})
+	if err != nil {
+		return
+	}
+	defer ch.Close()
+
+	err = ch.Switch(channel.Expect(&signed), channel.PassErrors)
+	return
+}

--- a/mod/user/errors.go
+++ b/mod/user/errors.go
@@ -4,3 +4,4 @@ import "github.com/cryptopunkscc/astrald/astral"
 
 var ErrInvitationDeclined = astral.NewError("invitation declined")
 var ErrRequestDeclined = astral.NewError("request declined")
+var ErrNoActiveContract = astral.NewError("no active contract")

--- a/mod/user/expulsion.go
+++ b/mod/user/expulsion.go
@@ -1,0 +1,69 @@
+package user
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/mod/crypto"
+)
+
+// Expulsion is the unsigned body of a swarm ban: Issuer permanently bans Subject
+// from the swarm. Wrap it in SignedExpulsion before storing, propagating, or
+// verifying. A ban is identity-level and irreversible.
+type Expulsion struct {
+	Issuer     *astral.Identity
+	Subject    *astral.Identity
+	ExpelledAt astral.Time
+}
+
+var _ crypto.SignableTextObject = &Expulsion{}
+
+func (Expulsion) ObjectType() string { return "mod.user.expulsion" }
+
+func (e Expulsion) WriteTo(w io.Writer) (int64, error)     { return astral.Objectify(&e).WriteTo(w) }
+func (e *Expulsion) ReadFrom(src io.Reader) (int64, error) { return astral.Objectify(e).ReadFrom(src) }
+
+func (e Expulsion) MarshalJSON() ([]byte, error)  { return astral.Objectify(&e).MarshalJSON() }
+func (e *Expulsion) UnmarshalJSON(b []byte) error { return astral.Objectify(e).UnmarshalJSON(b) }
+
+func (e *Expulsion) SignableHash() []byte {
+	id, err := astral.ResolveObjectID(e)
+	if err != nil {
+		return nil
+	}
+	return id.Hash[:]
+}
+
+func (e *Expulsion) SignableText() string {
+	return fmt.Sprintf("%s expels %s from the swarm", e.Issuer.String(), e.Subject.String())
+}
+
+// SignedExpulsion pairs an Expulsion body with the issuer's signature. It is the
+// wire, stored, and propagated form of a ban.
+type SignedExpulsion struct {
+	*Expulsion
+	IssuerSig *crypto.Signature
+}
+
+var _ astral.Object = &SignedExpulsion{}
+
+func (SignedExpulsion) ObjectType() string { return "mod.user.signed_expulsion" }
+
+func (e SignedExpulsion) WriteTo(w io.Writer) (int64, error) {
+	return astral.Objectify(&e).WriteTo(w)
+}
+func (e *SignedExpulsion) ReadFrom(src io.Reader) (int64, error) {
+	return astral.Objectify(e).ReadFrom(src)
+}
+
+func (e SignedExpulsion) MarshalJSON() ([]byte, error)  { return astral.Objectify(&e).MarshalJSON() }
+func (e *SignedExpulsion) UnmarshalJSON(b []byte) error { return astral.Objectify(e).UnmarshalJSON(b) }
+
+// IsNil guards against both a nil receiver and an embedded nil *Expulsion.
+func (e *SignedExpulsion) IsNil() bool { return e == nil || e.Expulsion == nil }
+
+func init() {
+	_ = astral.Add(&Expulsion{})
+	_ = astral.Add(&SignedExpulsion{})
+}

--- a/mod/user/expulsion_test.go
+++ b/mod/user/expulsion_test.go
@@ -1,0 +1,113 @@
+package user
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/mod/crypto"
+)
+
+// timeWithNanos is a fixed instant carrying sub-second precision, used to prove
+// ExpelledAt survives encode/decode and the DB column without losing nanoseconds
+// (astral.Time encodes as UnixNano, so the signature commits to that precision).
+func timeWithNanos() time.Time {
+	return time.Unix(1700000000, 123456789).UTC()
+}
+
+// sampleSignedExpulsion builds a SignedExpulsion with a dummy (non-cryptographic)
+// signature, sufficient for exercising encode/decode and hashing.
+func sampleSignedExpulsion() *SignedExpulsion {
+	return &SignedExpulsion{
+		Expulsion: &Expulsion{
+			Issuer:     astral.GenerateIdentity(),
+			Subject:    astral.GenerateIdentity(),
+			ExpelledAt: astral.Time(timeWithNanos()),
+		},
+		IssuerSig: &crypto.Signature{
+			Scheme: crypto.SchemeASN1,
+			Data:   astral.Bytes16("dummy-signature-bytes"),
+		},
+	}
+}
+
+func TestExpulsion_BinaryRoundTrip(t *testing.T) {
+	orig := sampleSignedExpulsion()
+
+	data, err := astral.EncodeBytes(orig)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	got, err := astral.DecodeAs[*SignedExpulsion](data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	assertSignedEqual(t, orig, got)
+}
+
+func TestExpulsion_JSONRoundTrip(t *testing.T) {
+	orig := sampleSignedExpulsion()
+
+	data, err := orig.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got SignedExpulsion
+	if err := got.UnmarshalJSON(data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	assertSignedEqual(t, orig, &got)
+}
+
+// TestExpulsion_Registered confirms both objects are registered with astral so
+// they can be decoded by type from the wire.
+func TestExpulsion_Registered(t *testing.T) {
+	for _, typ := range []string{"mod.user.expulsion", "mod.user.signed_expulsion"} {
+		if obj := astral.New(typ); obj == nil {
+			t.Fatalf("type %q not registered", typ)
+		}
+	}
+}
+
+func TestSignedExpulsion_IsNil(t *testing.T) {
+	var nilPtr *SignedExpulsion
+	if !nilPtr.IsNil() {
+		t.Fatal("nil receiver should report IsNil")
+	}
+	if !(&SignedExpulsion{}).IsNil() {
+		t.Fatal("embedded nil *Expulsion should report IsNil")
+	}
+	if sampleSignedExpulsion().IsNil() {
+		t.Fatal("fully populated value should not report IsNil")
+	}
+}
+
+func assertSignedEqual(t *testing.T, want, got *SignedExpulsion) {
+	t.Helper()
+
+	if !got.Issuer.IsEqual(want.Issuer) {
+		t.Errorf("issuer mismatch: got %v want %v", got.Issuer, want.Issuer)
+	}
+	if !got.Subject.IsEqual(want.Subject) {
+		t.Errorf("subject mismatch: got %v want %v", got.Subject, want.Subject)
+	}
+	if !got.ExpelledAt.Time().Equal(want.ExpelledAt.Time()) {
+		t.Errorf("expelledAt mismatch: got %v want %v", got.ExpelledAt.Time(), want.ExpelledAt.Time())
+	}
+	if got.IssuerSig.Scheme != want.IssuerSig.Scheme {
+		t.Errorf("sig scheme mismatch: got %v want %v", got.IssuerSig.Scheme, want.IssuerSig.Scheme)
+	}
+	if !bytes.Equal(got.IssuerSig.Data, want.IssuerSig.Data) {
+		t.Errorf("sig data mismatch")
+	}
+	// The signature commits to SignableHash, so a stable hash across the round
+	// trip is what guarantees the rebuilt object still verifies.
+	if !bytes.Equal(got.SignableHash(), want.SignableHash()) {
+		t.Errorf("signable hash changed across round trip")
+	}
+}

--- a/mod/user/module.go
+++ b/mod/user/module.go
@@ -21,6 +21,8 @@ const (
 	OpAssets          = "user.assets"
 	OpNewNodeContract = "user.new_node_contract"
 	OpSyncWith        = "user.sync_with"
+	OpExpel           = "user.expel"
+	OpListExpelled    = "user.list_expelled"
 )
 
 type Module interface {
@@ -36,4 +38,7 @@ type Module interface {
 	// PushToLocalSwarm broadcasts obj to every local swarm member except the
 	// node itself using ctx; delivery is best-effort and failures are silently ignored.
 	PushToLocalSwarm(ctx *astral.Context, obj astral.Object)
+	// Expel permanently bans nodeID from the swarm. Only the active contract's
+	// issuer may expel and the ban is irreversible.
+	Expel(ctx *astral.Context, nodeID *astral.Identity) (*SignedExpulsion, error)
 }

--- a/mod/user/src/assets.go
+++ b/mod/user/src/assets.go
@@ -6,7 +6,7 @@ import "github.com/cryptopunkscc/astrald/astral"
 func (mod *Module) AddAsset(objectID *astral.ObjectID) (err error) {
 	_, err = mod.db.AddAsset(objectID, false)
 	if err == nil {
-		mod.notifyLinkedSibs("assets")
+		mod.notifySiblings("assets")
 	}
 	return
 }
@@ -15,7 +15,7 @@ func (mod *Module) AddAsset(objectID *astral.ObjectID) (err error) {
 func (mod *Module) RemoveAsset(objectID *astral.ObjectID) (err error) {
 	err = mod.db.RemoveAsset(objectID)
 	if err == nil {
-		mod.notifyLinkedSibs("assets")
+		mod.notifySiblings("assets")
 	}
 	return err
 }

--- a/mod/user/src/contracts.go
+++ b/mod/user/src/contracts.go
@@ -62,12 +62,29 @@ func (mod *Module) setActiveContract(signed *auth.SignedContract) error {
 	return nil
 }
 
-// ActiveNodeContracts returns all active SwarmAccess contracts issued by userID
+// ActiveNodeContracts returns all active SwarmAccess contracts issued by userID,
+// excluding contracts whose subject has been expelled.
 func (mod *Module) ActiveNodeContracts(userID *astral.Identity) ([]*auth.SignedContract, error) {
-	return mod.Auth.SignedContracts().WithIssuer(userID).WithAction(&user.SwarmAccessAction{}).Find(mod.ctx)
+	contracts, err := mod.Auth.SignedContracts().WithIssuer(userID).WithAction(&user.SwarmAccessAction{}).Find(mod.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	expelled := mod.expelledSet(userID)
+
+	filtered := make([]*auth.SignedContract, 0, len(contracts))
+	for _, c := range contracts {
+		if _, banned := expelled[c.Subject.String()]; banned {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+
+	return filtered, nil
 }
 
-// ActiveNodes returns all nodes with an active SwarmAccess contract from the given user
+// ActiveNodes returns all nodes with an active SwarmAccess contract from the given
+// user, excluding expelled subjects.
 func (mod *Module) ActiveNodes(userID *astral.Identity) (nodes []*astral.Identity) {
 	contracts, err := mod.Auth.
 		SignedContracts().
@@ -80,7 +97,12 @@ func (mod *Module) ActiveNodes(userID *astral.Identity) (nodes []*astral.Identit
 		return
 	}
 
+	expelled := mod.expelledSet(userID)
+
 	for _, c := range contracts {
+		if _, banned := expelled[c.Subject.String()]; banned {
+			continue
+		}
 		nodes = append(nodes, c.Subject)
 	}
 
@@ -102,7 +124,7 @@ func (mod *Module) LocalSwarm() (list []*astral.Identity) {
 func (mod *Module) InviteNode(ctx *astral.Context, nodeID *astral.Identity) (signed *auth.SignedContract, err error) {
 	ac := mod.ActiveContract()
 	if ac == nil {
-		return nil, errors.New("no active contract")
+		return nil, user.ErrNoActiveContract
 	}
 
 	contract, err := user.NewNodeContract(ac.Issuer, nodeID, defaultContractValidity)

--- a/mod/user/src/db.go
+++ b/mod/user/src/db.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 
 	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/mod/crypto"
+	"github.com/cryptopunkscc/astrald/mod/user"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type DB struct {
@@ -133,5 +136,61 @@ func (db *DB) Assets() (assets []*astral.ObjectID, err error) {
 		Find(&assets).
 		Error
 
+	return
+}
+
+// StoreExpulsion records a ban for (issuer, subject). Bans are append-only and
+// irreversible: an existing row for the pair is left untouched.
+func (db *DB) StoreExpulsion(signed *user.SignedExpulsion) error {
+	sig, err := astral.EncodeBytes(signed.IssuerSig)
+	if err != nil {
+		return err
+	}
+
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(&dbExpulsion{
+		IssuerID:   signed.Issuer,
+		SubjectID:  signed.Subject,
+		ExpelledAt: signed.ExpelledAt.Time(),
+		IssuerSig:  sig,
+	}).Error
+}
+
+// ExpelledSubjects returns the subjects banned by issuer.
+func (db *DB) ExpelledSubjects(issuer *astral.Identity) (subjects []*astral.Identity, err error) {
+	var rows []dbExpulsion
+	err = db.Select("subject_id").Where("issuer_id = ?", issuer).Find(&rows).Error
+	if err != nil {
+		return
+	}
+
+	for _, row := range rows {
+		subjects = append(subjects, row.SubjectID)
+	}
+	return
+}
+
+// Expulsions rebuilds the signed bans issued by issuer from their stored columns.
+func (db *DB) Expulsions(issuer *astral.Identity) (list []*user.SignedExpulsion, err error) {
+	var rows []dbExpulsion
+	err = db.Where("issuer_id = ?", issuer).Find(&rows).Error
+	if err != nil {
+		return
+	}
+
+	for _, row := range rows {
+		sig, decodeErr := astral.DecodeAs[*crypto.Signature](row.IssuerSig)
+		if decodeErr != nil {
+			continue
+		}
+
+		list = append(list, &user.SignedExpulsion{
+			Expulsion: &user.Expulsion{
+				Issuer:     row.IssuerID,
+				Subject:    row.SubjectID,
+				ExpelledAt: astral.Time(row.ExpelledAt),
+			},
+			IssuerSig: sig,
+		})
+	}
 	return
 }

--- a/mod/user/src/db_expulsion.go
+++ b/mod/user/src/db_expulsion.go
@@ -1,0 +1,21 @@
+package user
+
+import (
+	"time"
+
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/mod/user"
+)
+
+// dbExpulsion stores one ban per (issuer, subject) pair, decomposed into columns
+// that rebuild the SignedExpulsion (mirroring how dbContract rebuilds a
+// SignedContract — no whole object held). Rows are append-only: a ban is never
+// updated or removed, matching the irreversible ban semantics.
+type dbExpulsion struct {
+	IssuerID   *astral.Identity `gorm:"primaryKey"`
+	SubjectID  *astral.Identity `gorm:"primaryKey"`
+	ExpelledAt time.Time
+	IssuerSig  []byte
+}
+
+func (dbExpulsion) TableName() string { return user.DBPrefix + "expulsions" }

--- a/mod/user/src/db_expulsion_test.go
+++ b/mod/user/src/db_expulsion_test.go
@@ -1,0 +1,140 @@
+package user
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/mod/crypto"
+	"github.com/cryptopunkscc/astrald/mod/user"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func testDB(t *testing.T) *DB {
+	t.Helper()
+
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	db := &DB{DB: gdb}
+	if err := db.AutoMigrate(&dbExpulsion{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func sampleSigned(issuer, subject *astral.Identity) *user.SignedExpulsion {
+	return &user.SignedExpulsion{
+		Expulsion: &user.Expulsion{
+			Issuer:  issuer,
+			Subject: subject,
+			// sub-second precision so the test catches a column that truncates it
+			ExpelledAt: astral.Time(time.Unix(1700000000, 123456789).UTC()),
+		},
+		IssuerSig: &crypto.Signature{
+			Scheme: crypto.SchemeASN1,
+			Data:   astral.Bytes16("dummy-signature-bytes"),
+		},
+	}
+}
+
+// TestStoreExpulsion_RoundTrip confirms a stored ban rebuilds with its
+// signature-committed fields intact — in particular ExpelledAt at nanosecond
+// precision, which the issuer signature commits to and a peer re-verifies.
+func TestStoreExpulsion_RoundTrip(t *testing.T) {
+	db := testDB(t)
+	issuer, subject := astral.GenerateIdentity(), astral.GenerateIdentity()
+	orig := sampleSigned(issuer, subject)
+
+	if err := db.StoreExpulsion(orig); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	list, err := db.Expulsions(issuer)
+	if err != nil {
+		t.Fatalf("expulsions: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 expulsion, got %d", len(list))
+	}
+
+	got := list[0]
+	if !got.Issuer.IsEqual(issuer) || !got.Subject.IsEqual(subject) {
+		t.Errorf("identity mismatch: issuer=%v subject=%v", got.Issuer, got.Subject)
+	}
+	if !got.ExpelledAt.Time().Equal(orig.ExpelledAt.Time()) {
+		t.Errorf("expelledAt not preserved: got %v want %v", got.ExpelledAt.Time(), orig.ExpelledAt.Time())
+	}
+	if got.IssuerSig.Scheme != orig.IssuerSig.Scheme || !bytes.Equal(got.IssuerSig.Data, orig.IssuerSig.Data) {
+		t.Errorf("signature not preserved")
+	}
+	// Equal signable hashes mean a peer verifying the rebuilt object against the
+	// stored signature would still succeed.
+	if !bytes.Equal(got.SignableHash(), orig.SignableHash()) {
+		t.Errorf("signable hash changed across DB round trip — signature would fail to verify")
+	}
+}
+
+// TestStoreExpulsion_Idempotent confirms re-storing the same (issuer, subject)
+// pair is a no-op, matching the append-only, irreversible ban semantics.
+func TestStoreExpulsion_Idempotent(t *testing.T) {
+	db := testDB(t)
+	issuer, subject := astral.GenerateIdentity(), astral.GenerateIdentity()
+
+	for i := 0; i < 2; i++ {
+		if err := db.StoreExpulsion(sampleSigned(issuer, subject)); err != nil {
+			t.Fatalf("store #%d: %v", i, err)
+		}
+	}
+
+	list, err := db.Expulsions(issuer)
+	if err != nil {
+		t.Fatalf("expulsions: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 row after duplicate store, got %d", len(list))
+	}
+}
+
+// TestExpelledSubjects returns exactly the banned subjects for an issuer.
+func TestExpelledSubjects(t *testing.T) {
+	db := testDB(t)
+	issuer := astral.GenerateIdentity()
+	s1, s2 := astral.GenerateIdentity(), astral.GenerateIdentity()
+
+	if err := db.StoreExpulsion(sampleSigned(issuer, s1)); err != nil {
+		t.Fatalf("store s1: %v", err)
+	}
+	if err := db.StoreExpulsion(sampleSigned(issuer, s2)); err != nil {
+		t.Fatalf("store s2: %v", err)
+	}
+
+	subjects, err := db.ExpelledSubjects(issuer)
+	if err != nil {
+		t.Fatalf("expelledSubjects: %v", err)
+	}
+	if len(subjects) != 2 {
+		t.Fatalf("expected 2 banned subjects, got %d", len(subjects))
+	}
+
+	found := map[string]bool{}
+	for _, s := range subjects {
+		found[s.String()] = true
+	}
+	if !found[s1.String()] || !found[s2.String()] {
+		t.Errorf("missing expected subjects in %v", subjects)
+	}
+
+	// A different issuer has no bans.
+	other, err := db.ExpelledSubjects(astral.GenerateIdentity())
+	if err != nil {
+		t.Fatalf("expelledSubjects(other): %v", err)
+	}
+	if len(other) != 0 {
+		t.Errorf("expected no bans for unrelated issuer, got %d", len(other))
+	}
+}

--- a/mod/user/src/expel.go
+++ b/mod/user/src/expel.go
@@ -1,0 +1,114 @@
+package user
+
+import (
+	"errors"
+	"time"
+
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/mod/objects"
+	"github.com/cryptopunkscc/astrald/mod/secp256k1"
+	"github.com/cryptopunkscc/astrald/mod/user"
+)
+
+// Expel permanently bans nodeID from the active swarm. Only the swarm's user (the
+// active contract's issuer) may expel, and the ban cannot be undone. The signed
+// ban is stored, pushed to the local swarm, and the node is disconnected.
+//
+// Expelling suppresses swarm membership only; it does not revoke the node's
+// underlying SwarmAccess contract.
+func (mod *Module) Expel(ctx *astral.Context, nodeID *astral.Identity) (*user.SignedExpulsion, error) {
+	ac := mod.ActiveContract()
+	if ac == nil {
+		return nil, user.ErrNoActiveContract
+	}
+
+	if nodeID.IsEqual(ac.Issuer) {
+		return nil, errors.New("cannot expel the swarm user")
+	}
+
+	expulsion := &user.Expulsion{
+		Issuer:     ac.Issuer,
+		Subject:    nodeID,
+		ExpelledAt: astral.Time(time.Now()),
+	}
+
+	sig, err := mod.Crypto.Sign(ctx, secp256k1.FromIdentity(ac.Issuer), expulsion)
+	if err != nil {
+		return nil, err
+	}
+
+	signed := &user.SignedExpulsion{Expulsion: expulsion, IssuerSig: sig}
+
+	err = mod.db.StoreExpulsion(signed)
+	if err != nil {
+		return nil, err
+	}
+
+	go mod.PushToLocalSwarm(mod.ctx, signed)
+	mod.applyExpulsion(nodeID)
+
+	mod.log.Info("expelled %v from swarm", nodeID)
+	return signed, nil
+}
+
+// receiveExpulsion handles an inbound signed ban. It is accepted only when issued
+// by the active swarm user and carrying a valid issuer signature, then stored and
+// enforced by disconnecting the subject.
+func (mod *Module) receiveExpulsion(signed *user.SignedExpulsion) error {
+	if signed.IsNil() {
+		return objects.ErrPushRejected
+	}
+
+	ac := mod.ActiveContract()
+	if ac == nil || !signed.Issuer.IsEqual(ac.Issuer) {
+		return objects.ErrPushRejected
+	}
+
+	if err := mod.verifyExpulsion(signed); err != nil {
+		mod.log.Errorv(1, "invalid expulsion: %v", err)
+		return objects.ErrPushRejected
+	}
+
+	if err := mod.db.StoreExpulsion(signed); err != nil {
+		mod.log.Errorv(1, "storing expulsion failed: %v", err)
+		return objects.ErrPushRejected
+	}
+
+	mod.applyExpulsion(signed.Subject)
+	return nil
+}
+
+// applyExpulsion tears down all live ties to id: it disconnects open links and
+// stops the sibling link-maintenance task. Membership filtering already prevents
+// re-linking once the ban is stored.
+func (mod *Module) applyExpulsion(id *astral.Identity) {
+	if err := mod.Nodes.CloseLinks(id); err != nil {
+		mod.log.Errorv(1, "closing links to expelled %v: %v", id, err)
+	}
+	mod.removeSibling(id)
+}
+
+// expelledSet returns the subjects banned by issuer, keyed by identity string for
+// O(1) membership filtering.
+func (mod *Module) expelledSet(issuer *astral.Identity) map[string]struct{} {
+	subjects, err := mod.db.ExpelledSubjects(issuer)
+	if err != nil {
+		mod.log.Errorv(1, "error reading expulsions: %v", err)
+		return nil
+	}
+
+	set := make(map[string]struct{}, len(subjects))
+	for _, s := range subjects {
+		set[s.String()] = struct{}{}
+	}
+	return set
+}
+
+// verifyExpulsion checks that the issuer signature is present and valid.
+func (mod *Module) verifyExpulsion(signed *user.SignedExpulsion) error {
+	if signed.IssuerSig == nil {
+		return errors.New("missing issuer signature")
+	}
+
+	return mod.Crypto.Verify(secp256k1.FromIdentity(signed.Issuer), signed.IssuerSig, signed.Expulsion)
+}

--- a/mod/user/src/loader.go
+++ b/mod/user/src/loader.go
@@ -27,7 +27,7 @@ func (Loader) Load(node astral.Node, assets assets.Assets, log *log.Logger) (cor
 
 	mod.db = &DB{DB: assets.Database(), mod: mod}
 
-	err = mod.db.AutoMigrate(&dbAsset{})
+	err = mod.db.AutoMigrate(&dbAsset{}, &dbExpulsion{})
 	if err != nil {
 		return nil, err
 	}

--- a/mod/user/src/object_finder.go
+++ b/mod/user/src/object_finder.go
@@ -11,7 +11,7 @@ func (mod *Module) FindObject(ctx *astral.Context, id *astral.ObjectID) (<-chan 
 	go func() {
 		defer close(out)
 
-		for _, sib := range mod.getLinkedSibs() {
+		for _, sib := range mod.getSiblings() {
 			select {
 			case out <- sib:
 			case <-ctx.Done():

--- a/mod/user/src/object_receiver.go
+++ b/mod/user/src/object_receiver.go
@@ -22,6 +22,11 @@ func (mod *Module) ReceiveObject(drop objects.Drop) (err error) {
 		if err == nil {
 			drop.Accept(true)
 		}
+	case *user.SignedExpulsion:
+		err = mod.receiveExpulsion(o)
+		if err == nil {
+			drop.Accept(true)
+		}
 	case *events.Event:
 		switch e := o.Data.(type) {
 		case *nodes.LinkCreatedEvent:

--- a/mod/user/src/op_expel.go
+++ b/mod/user/src/op_expel.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/astral/channel"
+	"github.com/cryptopunkscc/astrald/lib/routing"
+)
+
+type opExpelArgs struct {
+	Target string
+	In     string `query:"optional"`
+	Out    string `query:"optional"`
+}
+
+// OpExpel permanently bans the target node from the swarm and returns the signed ban.
+// Requires an active contract; caller must be the contract issuer (code 3 otherwise).
+func (mod *Module) OpExpel(ctx *astral.Context, q *routing.IncomingQuery, args opExpelArgs) (err error) {
+	ac := mod.ActiveContract()
+	if ac == nil {
+		return q.RejectWithCode(2)
+	}
+
+	if !q.Caller().IsEqual(ac.Issuer) {
+		return q.RejectWithCode(3)
+	}
+
+	ch := q.Accept(channel.WithFormats(args.In, args.Out))
+	defer ch.Close()
+
+	nodeID, err := mod.Dir.ResolveIdentity(args.Target)
+	if err != nil {
+		return ch.Send(astral.Err(err))
+	}
+
+	signed, err := mod.Expel(ctx, nodeID)
+	if err != nil {
+		return ch.Send(astral.Err(err))
+	}
+
+	return ch.Send(signed)
+}

--- a/mod/user/src/op_list_expelled.go
+++ b/mod/user/src/op_list_expelled.go
@@ -1,0 +1,37 @@
+package user
+
+import (
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/astral/channel"
+	"github.com/cryptopunkscc/astrald/lib/routing"
+)
+
+type opListExpelledArgs struct {
+	Out string `query:"optional"`
+}
+
+// OpListExpelled streams the signed bans issued by the active swarm user, terminated by EOS.
+// Readable by any caller, matching OpListSiblings / OpSwarmStatus.
+func (mod *Module) OpListExpelled(ctx *astral.Context, q *routing.IncomingQuery, args opListExpelledArgs) (err error) {
+	ac := mod.ActiveContract()
+	if ac == nil {
+		return q.RejectWithCode(2)
+	}
+
+	ch := q.Accept(channel.WithOutputFormat(args.Out))
+	defer ch.Close()
+
+	expulsions, err := mod.db.Expulsions(ac.Issuer)
+	if err != nil {
+		return ch.Send(astral.NewError(err.Error()))
+	}
+
+	for _, se := range expulsions {
+		err = ch.Send(se)
+		if err != nil {
+			return ch.Send(astral.NewError(err.Error()))
+		}
+	}
+
+	return ch.Send(&astral.EOS{})
+}

--- a/mod/user/src/op_list_siblings.go
+++ b/mod/user/src/op_list_siblings.go
@@ -20,7 +20,7 @@ func (mod *Module) OpListSiblings(ctx *astral.Context, q *routing.IncomingQuery,
 	ch := channel.New(q.AcceptRaw(), channel.WithOutputFormat(args.Out))
 	defer ch.Close()
 
-	for _, id := range mod.getLinkedSibs() {
+	for _, id := range mod.getSiblings() {
 		err = ch.Send(id)
 		if err != nil {
 			return ch.Send(astral.NewError(err.Error()))

--- a/mod/user/src/query_preprocessor.go
+++ b/mod/user/src/query_preprocessor.go
@@ -23,7 +23,7 @@ func (mod *Module) PreprocessQuery(qm *core.QueryModifier) error {
 
 	if qm.Query().Target.IsEqual(ac.Issuer) {
 		// if the target is the active user, attach all siblings
-		for _, sib := range mod.getLinkedSibs() {
+		for _, sib := range mod.getSiblings() {
 			qm.AddRelay(sib)
 		}
 	} else {

--- a/mod/user/src/search_preprocessor.go
+++ b/mod/user/src/search_preprocessor.go
@@ -13,7 +13,7 @@ func (mod *Module) PreprocessSearch(search *objects.Search) {
 		return
 	}
 
-	for _, nodeID := range mod.getLinkedSibs() {
+	for _, nodeID := range mod.getSiblings() {
 		search.Sources = append(search.Sources, nodeID)
 	}
 }

--- a/mod/user/src/siblings.go
+++ b/mod/user/src/siblings.go
@@ -7,36 +7,43 @@ import (
 	"github.com/cryptopunkscc/astrald/mod/user"
 )
 
-// Sibling tracks a connected peer node that shares the same active contract (user).
-// Cancel terminates the background goroutine that maintains the sibling link.
+// Sibling is a link-maintenance entry for one swarm peer: the tracked node plus
+// the Cancel that stops its background link-maintenance goroutine.
 type Sibling struct {
 	ID     *astral.Identity
 	Cancel context.CancelFunc
 }
 
-func (mod *Module) notifyLinkedSibs(event string) {
+func (mod *Module) notifySiblings(event string) {
 	ac := mod.ActiveContract()
 	if ac == nil {
 		return
 	}
 
-	for _, sib := range mod.getLinkedSibs() {
+	for _, sib := range mod.getSiblings() {
 		sib := sib
 		go mod.Objects.Push(mod.ctx, sib, &user.Notification{Event: astral.String8(event)})
 	}
 }
 
-func (mod *Module) getLinkedSibs() (list []*astral.Identity) {
-	for _, sib := range mod.sibs.Values() {
-		list = append(list, sib.ID)
+// getSiblings returns the swarm members this node currently holds a live link
+// with, excluding the local node. Membership comes from LocalSwarm (contract-
+// derived, expel-aware); liveness from Nodes.IsLinked. It is independent of the
+// sibs maintenance registry, so a stale or not-yet-linked entry never leaks through.
+func (mod *Module) getSiblings() (list []*astral.Identity) {
+	self := mod.node.Identity()
+
+	for _, node := range mod.LocalSwarm() {
+		if node.IsEqual(self) || !mod.Nodes.IsLinked(node) {
+			continue
+		}
+		list = append(list, node)
 	}
 
-	return list
+	return
 }
 
-func (mod *Module) addSibling(id *astral.Identity,
-	cancel context.CancelFunc) {
-
+func (mod *Module) addSibling(id *astral.Identity, cancel context.CancelFunc) {
 	mod.log.Log("adding sibling %v", id)
 	mod.sibs.Set(id.String(), Sibling{
 		ID:     id,
@@ -45,9 +52,11 @@ func (mod *Module) addSibling(id *astral.Identity,
 }
 
 func (mod *Module) removeSibling(id *astral.Identity) {
-	sib, ok := mod.sibs.Get(id.String())
-	if ok {
-		mod.log.Log("removing sibling %v", id)
-		sib.Cancel()
+	sib, ok := mod.sibs.Delete(id.String())
+	if !ok {
+		return
 	}
+
+	mod.log.Log("removing sibling %v", id)
+	sib.Cancel()
 }

--- a/mod/user/src/sync.go
+++ b/mod/user/src/sync.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/cryptopunkscc/astrald/astral"
@@ -16,7 +15,7 @@ import (
 func (mod *Module) syncAssets(ctx *astral.Context, nodeID *astral.Identity) (err error) {
 	ac := mod.ActiveContract()
 	if ac == nil {
-		return errors.New("no active contract")
+		return user.ErrNoActiveContract
 	}
 
 	nodePath := fmt.Sprintf("/mod/user/assets/%v/next_height", nodeID.String())
@@ -71,7 +70,7 @@ func (mod *Module) syncAssets(ctx *astral.Context, nodeID *astral.Identity) (err
 func (mod *Module) syncAlias(ctx *astral.Context, nodeID *astral.Identity) (err error) {
 	ac := mod.ActiveContract()
 	if ac == nil {
-		return errors.New("no active contract")
+		return user.ErrNoActiveContract
 	}
 
 	var q = query.New(ac.Issuer, nodeID, user.OpInfo, nil)
@@ -128,6 +127,29 @@ func (mod *Module) syncSiblings(ctx *astral.Context, with *astral.Identity) {
 		mod.Objects.Push(ctx, with, contract)
 	}
 
+}
+
+// syncExpulsions pushes every ban issued by the active user to the remote node,
+// so a peer that was offline during an expel still learns the ban on next link.
+func (mod *Module) syncExpulsions(ctx *astral.Context, with *astral.Identity) {
+	ac := mod.ActiveContract()
+	if ac == nil {
+		return
+	}
+
+	expulsions, err := mod.db.Expulsions(ac.Issuer)
+	if err != nil {
+		mod.log.Error("syncExpulsions: error getting expulsions: %v", err)
+		return
+	}
+
+	for _, signed := range expulsions {
+		if signed.Subject.IsEqual(with) {
+			continue
+		}
+
+		mod.Objects.Push(ctx, with, signed)
+	}
 }
 
 func (mod *Module) syncApps(ctx *astral.Context, with *astral.Identity) {

--- a/mod/user/src/sync_nodes_action.go
+++ b/mod/user/src/sync_nodes_action.go
@@ -40,6 +40,7 @@ func (a *SyncNodesAction) Run(ctx *astral.Context) error {
 
 	a.mod.pushActiveContract(ctx, remoteIdentity)
 	a.mod.syncSiblings(ctx, remoteIdentity)
+	a.mod.syncExpulsions(ctx, remoteIdentity)
 	a.mod.syncApps(ctx, remoteIdentity)
 
 	err = a.mod.syncAssets(ctx, remoteIdentity)


### PR DESCRIPTION
Expel permanently bans a node identity from the swarm. A ban is signed by the swarm user (active contract issuer), stored DB-backed (append-only, irreversible), pushed to the local swarm, and re-served on sibling sync so offline/late-joining peers converge. Enforcement is a single membership chokepoint: ActiveNodes/ActiveNodeContracts drop expelled subjects, which removes them from LocalSwarm, the localswarm filter, relay/read authorization, and OpInfo. Expelling does not revoke the SwarmAccess contract (revocation is a separate auth-layer feature).

- mod/user: Expulsion/SignedExpulsion wire objects, DB storage, Expel + receive/sync paths, OpExpel/OpListExpelled ops, client.Expel.
- mod/user/src/siblings.go: derive the live-sibling view from LocalSwarm ∩ Nodes.IsLinked (expel-aware) instead of the maintenance registry; removeSibling now deletes the entry.
- mod/nodes: add CloseLinks(identity) to disconnect an expelled node.
- mod/crypto: expose Sign/Verify (scheme-selecting dispatch) as the shared home; mod/auth signing now delegates to them.
- tests: first tests under mod/user — object + storage round-trips, asserting ExpelledAt/SignableHash survive the time.Time column so a rebuilt ban still verifies.