### PR TITLE
fix(fs): map missing-file Delete to objects.ErrNotFound

### DIFF
--- a/mod/fs/src/repository.go
+++ b/mod/fs/src/repository.go
@@ -171,7 +171,12 @@ func (repo *Repository) Free(ctx *astral.Context) (int64, error) {
 
 func (repo *Repository) Delete(ctx *astral.Context, objectID *astral.ObjectID) error {
 	path := filepath.Join(repo.root, objectID.String())
-	return os.Remove(path)
+	err := os.Remove(path)
+	// why: map a missing-file miss to ErrNotFound so purge skips this leaf instead of aborting the whole pass
+	if os.IsNotExist(err) {
+		return objects.ErrNotFound
+	}
+	return err
 }
 
 func (repo *Repository) String() string {

--- a/mod/fs/src/repository_test.go
+++ b/mod/fs/src/repository_test.go
@@ -1,0 +1,42 @@
+package fs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cryptopunkscc/astrald/astral"
+	"github.com/cryptopunkscc/astrald/mod/objects"
+)
+
+// Delete maps a missing-file os.Remove error to objects.ErrNotFound so purge skips the leaf.
+func TestRepository_Delete_MissingFile(t *testing.T) {
+	repo := NewRepository(nil, "test", t.TempDir())
+	id := &astral.ObjectID{Size: 1}
+
+	err := repo.Delete(nil, id)
+
+	if !errors.Is(err, objects.ErrNotFound) {
+		t.Fatalf("want objects.ErrNotFound, got %v", err)
+	}
+}
+
+// Delete removes an existing object file and returns no error.
+func TestRepository_Delete_ExistingFile(t *testing.T) {
+	root := t.TempDir()
+	repo := NewRepository(nil, "test", root)
+	id := &astral.ObjectID{Size: 1}
+
+	path := filepath.Join(root, id.String())
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.Delete(nil, id); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("file still exists: %v", err)
+	}
+}


### PR DESCRIPTION
(*fs.Repository).Delete returned the raw os.Remove *PathError on a missing file. purgeRepository switches on the delete error: only objects.ErrNotFound is skipped, everything else aborts the whole purge. A leaf-fs miss therefore killed the entire purge pass.

Map the os.IsNotExist case to objects.ErrNotFound so a stale cache row is dropped and purge continues. Add focused tests for the missing- and existing-file paths.

Origin: R3 of the dev/purge-order review.