### PR TITLE
Bump astral-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/coder/websocket v1.8.14
-	github.com/cryptopunkscc/astral-go v0.0.0-20260707202010-48a208d07469
+	github.com/cryptopunkscc/astral-go v0.0.0-20260708131549-393955a6da59
 	github.com/cryptopunkscc/bip-0137 v0.0.0-20260118232723-438bbbb8fe46
 	github.com/cryptopunkscc/utp v0.0.0-20251010115525-2f03809eff3d
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -53,10 +53,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
-github.com/cryptopunkscc/astral-go v0.0.0-20260707122723-064584370901 h1:bwQl8FP75i/Hj/wrQ4VL6BqGh/CPScyjgT5Yj5Jr100=
-github.com/cryptopunkscc/astral-go v0.0.0-20260707122723-064584370901/go.mod h1:WE+P8hMP2bwP92KkcLgWnaqXdQ6dOxsiJJKLLlLorWA=
-github.com/cryptopunkscc/astral-go v0.0.0-20260707202010-48a208d07469 h1:+VWcMDZQIkCKTlg8TmldQD8SjK1iWKy+7mDqo+tvYj4=
-github.com/cryptopunkscc/astral-go v0.0.0-20260707202010-48a208d07469/go.mod h1:WE+P8hMP2bwP92KkcLgWnaqXdQ6dOxsiJJKLLlLorWA=
+github.com/cryptopunkscc/astral-go v0.0.0-20260708131549-393955a6da59 h1:fzosb0V/lL5dzEhDlsMxpIjPaOeDVoKr6HdHz7JMrPA=
+github.com/cryptopunkscc/astral-go v0.0.0-20260708131549-393955a6da59/go.mod h1:WE+P8hMP2bwP92KkcLgWnaqXdQ6dOxsiJJKLLlLorWA=
 github.com/cryptopunkscc/bip-0137 v0.0.0-20260118232723-438bbbb8fe46 h1:ACHkKEMJ9jX3g0vZ/ck9XXy3Qh/aHf1idjcWkY9ZZ7A=
 github.com/cryptopunkscc/bip-0137 v0.0.0-20260118232723-438bbbb8fe46/go.mod h1:/dhiF6QcnbnpTZ+3XTtAvrfDeLDoQzm5j0aiXXRniiY=
 github.com/cryptopunkscc/utp v0.0.0-20251010115525-2f03809eff3d h1:mj/jUJQzlrDuQaLhsDCxDuXbqBEfEbAfjEHh63I7uOM=


### PR DESCRIPTION
astral-go v0.0.0-20260708131549-393955a6da59 carries the nil-object decode fix for a null JSON payload (astral-go #7): a known-type frame with a null Object now decodes to a non-nil astral.Object instead of returning (nil, nil). The prior pin, 48a208d, predates it.

go build ./... and go test ./... pass. go mod tidy pruned the superseded astral-go go.sum entries.